### PR TITLE
fix(mac): use osascript for Cmd+C to avoid Chinese IME conflict

### DIFF
--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -247,17 +247,46 @@ impl PipelineHandle {
         let mut clipboard = arboard::Clipboard::new().ok()?;
         let backup = clipboard.get_text().ok();
 
-        if let Ok(mut enigo) = Enigo::new(&EnigoSettings::default()) {
-            #[cfg(target_os = "macos")]
-            let modifier = Key::Meta;
-            #[cfg(not(target_os = "macos"))]
-            let modifier = Key::Control;
-
-            let pressed = enigo.key(modifier, Direction::Press).is_ok();
-            if pressed {
-                let _ = enigo.key(Key::Unicode('c'), Direction::Click);
-                let _ = enigo.key(modifier, Direction::Release);
+        // Use osascript to simulate Cmd+C on macOS to avoid triggering
+        // the Chinese input method (Enigo's CGEventPost interferes with it).
+        #[cfg(target_os = "macos")]
+        {
+            let status = std::process::Command::new("osascript")
+                .args([
+                    "-e",
+                    r#"tell application "System Events" to keystroke "c" using command down"#,
+                ])
+                .status();
+            match status {
+                Ok(s) if s.success() => {}
+                _ => {
+                    tracing::warn!("osascript Cmd+C failed, falling back to Enigo");
+                    // Fallback to Enigo if osascript fails
+                    let app_handle = self.app_handle.clone();
+                    let _ = app_handle.run_on_main_thread(move || {
+                        let mut enigo = match Enigo::new(&EnigoSettings::default()) {
+                            Ok(e) => e,
+                            Err(_) => return,
+                        };
+                        let _ = enigo.key(Key::Meta, Direction::Press);
+                        let _ = enigo.key(Key::Unicode('c'), Direction::Click);
+                        let _ = enigo.key(Key::Meta, Direction::Release);
+                    });
+                }
             }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let app_handle = self.app_handle.clone();
+            let _ = app_handle.run_on_main_thread(move || {
+                let mut enigo = match Enigo::new(&EnigoSettings::default()) {
+                    Ok(e) => e,
+                    Err(_) => return,
+                };
+                let _ = enigo.key(Key::Control, Direction::Press);
+                let _ = enigo.key(Key::Unicode('c'), Direction::Click);
+                let _ = enigo.key(Key::Control, Direction::Release);
+            });
         }
 
         std::thread::sleep(std::time::Duration::from_millis(CLIPBOARD_COPY_SETTLE_MS));


### PR DESCRIPTION
## Summary

Fix Chinese input method (IME) popup appearing when simulating Cmd+C during text selection on macOS. Enigo's `CGEventPost` interferes with the system IME, causing unwanted input method UI to appear.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Changes

Enigo's CGEventPost triggers the Chinese input method when simulating Cmd+C, causing input method popup to appear.

- Use osascript (AppleScript) to simulate Cmd+C on macOS
- Falls back to Enigo if osascript fails
- Linux/Windows still use Enigo (Assuming no IME issue)

## Test Plan

- [x] Tested locally on macOS 26.5 (25F71) ARM-64
- [x] `npm run build` passes
- [x] `npx vitest run` passes (pre-existing failures in api.test.ts/authStore.test.ts unrelated to this change)
- [x] `cargo clippy -- -D warnings` passes
- [x] No regressions in existing functionality

## Screenshots / Recordings

N/A (no UI changes)

## Related Issues

Fixes Chinese IME popup during text selection on macOS