### PR TITLE
fix(mac): move Enigo::new() to main thread for macOS 26.5 compat

### DIFF
--- a/src-tauri/src/output/keyboard.rs
+++ b/src-tauri/src/output/keyboard.rs
@@ -33,17 +33,19 @@ pub fn check_keyboard_available() -> std::result::Result<(), String> {
     Ok(())
 }
 
-pub struct KeyboardOutput;
+pub struct KeyboardOutput {
+    app_handle: tauri::AppHandle,
+}
 
 impl Default for KeyboardOutput {
     fn default() -> Self {
-        Self::new()
+        panic!("KeyboardOutput::default() must not be used — use KeyboardOutput::new(app_handle) instead");
     }
 }
 
 impl KeyboardOutput {
-    pub fn new() -> Self {
-        Self
+    pub fn new(app_handle: tauri::AppHandle) -> Self {
+        Self { app_handle }
     }
 }
 
@@ -51,38 +53,48 @@ impl KeyboardOutput {
 impl TextOutput for KeyboardOutput {
     async fn type_text(&self, text: &str) -> Result<(), AppError> {
         let text = text.to_string();
-        tokio::task::spawn_blocking(move || -> Result<(), AppError> {
-            let mut enigo = Enigo::new(&Settings::default())
-                .map_err(|e| AppError::Output(format!("Failed to create Enigo: {:?}", e)))?;
+        let app_handle = self.app_handle.clone();
+        // macOS 26.5 requires TSM APIs (used by Enigo::new()) to run on the
+        // main dispatch queue. Enigo is !Send, so the entire typing operation
+        // must happen on the main thread.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let _ = app_handle.run_on_main_thread(move || {
+            let result = (|| -> Result<(), AppError> {
+                let mut enigo = Enigo::new(&Settings::default())
+                    .map_err(|e| AppError::Output(format!("Failed to create Enigo: {:?}", e)))?;
 
-            let lines: Vec<&str> = text.split('\n').collect();
-            for (i, line) in lines.iter().enumerate() {
-                if !line.is_empty() {
-                    for chunk in line.chars().collect::<Vec<_>>().chunks(TYPE_CHUNK_SIZE) {
-                        let s: String = chunk.iter().collect();
-                        enigo.text(&s).map_err(|e| {
-                            AppError::Output(format!("Failed to type text: {:?}", e))
-                        })?;
-                        std::thread::sleep(std::time::Duration::from_millis(TYPE_CHUNK_DELAY_MS));
+                let lines: Vec<&str> = text.split('\n').collect();
+                for (i, line) in lines.iter().enumerate() {
+                    if !line.is_empty() {
+                        for chunk in line.chars().collect::<Vec<_>>().chunks(TYPE_CHUNK_SIZE) {
+                            let s: String = chunk.iter().collect();
+                            enigo.text(&s).map_err(|e| {
+                                AppError::Output(format!("Failed to type text: {:?}", e))
+                            })?;
+                            std::thread::sleep(std::time::Duration::from_millis(
+                                TYPE_CHUNK_DELAY_MS,
+                            ));
+                        }
+                    }
+                    if i < lines.len() - 1 {
+                        enigo
+                            .key(Key::Shift, Direction::Press)
+                            .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
+                        enigo
+                            .key(Key::Return, Direction::Click)
+                            .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
+                        enigo
+                            .key(Key::Shift, Direction::Release)
+                            .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
                     }
                 }
-                if i < lines.len() - 1 {
-                    enigo
-                        .key(Key::Shift, Direction::Press)
-                        .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
-                    enigo
-                        .key(Key::Return, Direction::Click)
-                        .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
-                    enigo
-                        .key(Key::Shift, Direction::Release)
-                        .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
-                }
-            }
 
-            Ok(())
-        })
-        .await
-        .map_err(|e| AppError::Output(format!("Spawn blocking error: {}", e)))?
+                Ok(())
+            })();
+            let _ = tx.send(result);
+        });
+        rx.recv()
+            .map_err(|e| AppError::Output(format!("Main thread task dropped: {}", e)))?
     }
 
     fn mode(&self) -> OutputMode {

--- a/src-tauri/src/output/mod.rs
+++ b/src-tauri/src/output/mod.rs
@@ -16,9 +16,9 @@ pub trait TextOutput: Send + Sync {
     fn mode(&self) -> OutputMode;
 }
 
-pub fn create_output(mode: OutputMode) -> Box<dyn TextOutput> {
+pub fn create_output(mode: OutputMode, app_handle: &tauri::AppHandle) -> Box<dyn TextOutput> {
     match mode {
-        OutputMode::Keyboard => Box::new(keyboard::KeyboardOutput::new()),
+        OutputMode::Keyboard => Box::new(keyboard::KeyboardOutput::new(app_handle.clone())),
         OutputMode::Clipboard => Box::new(clipboard::ClipboardOutput::new()),
     }
 }
@@ -28,11 +28,12 @@ pub fn create_output(mode: OutputMode) -> Box<dyn TextOutput> {
 /// Returns Ok(None) if primary output succeeded.
 /// Returns Err if both keyboard and clipboard failed.
 pub async fn output_with_fallback(
+    app_handle: &tauri::AppHandle,
     text: &str,
     mode: OutputMode,
 ) -> Result<Option<UserError>, String> {
     if mode == OutputMode::Clipboard {
-        let output = create_output(OutputMode::Clipboard);
+        let output = create_output(OutputMode::Clipboard, app_handle);
         return output
             .type_text(text)
             .await
@@ -41,7 +42,7 @@ pub async fn output_with_fallback(
     }
 
     // Try keyboard first
-    let keyboard = create_output(OutputMode::Keyboard);
+    let keyboard = create_output(OutputMode::Keyboard, app_handle);
     match keyboard.type_text(text).await {
         Ok(()) => Ok(None),
         Err(kb_err) => {
@@ -49,7 +50,7 @@ pub async fn output_with_fallback(
                 "Keyboard output failed: {}, falling back to clipboard",
                 kb_err
             );
-            let clipboard = create_output(OutputMode::Clipboard);
+            let clipboard = create_output(OutputMode::Clipboard, app_handle);
             match clipboard.type_text(text).await {
                 Ok(()) => Ok(Some(UserError {
                     code: "output_fallback_clipboard".to_string(),

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -35,64 +35,21 @@ pub fn is_accessibility_trusted() -> bool {
     }
 }
 
-/// On macOS, request Accessibility permission by showing the system authorization dialog.
-/// Uses AXIsProcessTrustedWithOptions with kAXTrustedCheckOptionPrompt = true.
-/// Returns true if permission is already granted or on non-macOS platforms.
+/// On macOS, request Accessibility permission by opening System Settings
+/// to the Accessibility privacy pane. Returns true if permission is already granted
+/// or on non-macOS platforms.
 pub fn request_accessibility_permission() -> bool {
     #[cfg(target_os = "macos")]
     {
-        #[link(name = "ApplicationServices", kind = "framework")]
-        extern "C" {
-            fn AXIsProcessTrustedWithOptions(options: *mut std::ffi::c_void) -> u8;
+        if is_accessibility_trusted() {
+            return true;
         }
-        #[link(name = "CoreFoundation", kind = "framework")]
-        extern "C" {
-            fn CFDictionaryCreate(
-                allocator: *mut std::ffi::c_void,
-                keys: *const *mut std::ffi::c_void,
-                values: *const *mut std::ffi::c_void,
-                num_values: isize,
-                key_callbacks: *const std::ffi::c_void,
-                value_callbacks: *const std::ffi::c_void,
-            ) -> *mut std::ffi::c_void;
-            fn CFStringCreateWithCString(
-                allocator: *mut std::ffi::c_void,
-                c_str: *const i8,
-                encoding: u32,
-            ) -> *mut std::ffi::c_void;
-            static kCFTypeDictionaryKeyCallBacks: std::ffi::c_void;
-            static kCFTypeDictionaryValueCallBacks: std::ffi::c_void;
-        }
-        // kCFBooleanTrue — we link CoreFoundation and use the known address pattern
-        #[link(name = "CoreFoundation", kind = "framework")]
-        extern "C" {
-            static kCFBooleanTrue: *mut std::ffi::c_void;
-        }
-        // kCFStringEncodingUTF8 = 0x08000100
-        const K_CF_STRING_ENCODING_UTF8: u32 = 0x08000100;
-
-        #[allow(clippy::manual_c_str_literals)]
-        unsafe {
-            let key = CFStringCreateWithCString(
-                std::ptr::null_mut(),
-                b"kAXTrustedCheckOptionPrompt\0".as_ptr() as *const i8,
-                K_CF_STRING_ENCODING_UTF8,
-            );
-            let value = kCFBooleanTrue;
-
-            let options = CFDictionaryCreate(
-                std::ptr::null_mut(),
-                &[key] as *const *mut std::ffi::c_void,
-                &[value] as *const *mut std::ffi::c_void,
-                1,
-                &kCFTypeDictionaryKeyCallBacks as *const std::ffi::c_void,
-                &kCFTypeDictionaryValueCallBacks as *const std::ffi::c_void,
-            );
-
-            let trusted = AXIsProcessTrustedWithOptions(options);
-            // options is leaked (trivial — called at most a few times)
-            trusted != 0
-        }
+        // AXIsProcessTrustedWithOptions crashes on macOS 26.5, so we open
+        // System Settings directly and let the user add the app manually.
+        let _ = std::process::Command::new("open")
+            .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+            .status();
+        false
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -247,18 +204,24 @@ impl PipelineHandle {
         let mut clipboard = arboard::Clipboard::new().ok()?;
         let backup = clipboard.get_text().ok();
 
-        if let Ok(mut enigo) = Enigo::new(&EnigoSettings::default()) {
+        // macOS 26.5 requires TSM APIs (used by Enigo::new()) to run on the
+        // main dispatch queue. Dispatch the Enigo creation + Cmd+C simulation
+        // to the main thread.
+        let app_handle = self.app_handle.clone();
+        let _ = app_handle.run_on_main_thread(move || {
+            let mut enigo = match Enigo::new(&EnigoSettings::default()) {
+                Ok(e) => e,
+                Err(_) => return,
+            };
             #[cfg(target_os = "macos")]
             let modifier = Key::Meta;
             #[cfg(not(target_os = "macos"))]
             let modifier = Key::Control;
 
-            let pressed = enigo.key(modifier, Direction::Press).is_ok();
-            if pressed {
-                let _ = enigo.key(Key::Unicode('c'), Direction::Click);
-                let _ = enigo.key(modifier, Direction::Release);
-            }
-        }
+            let _ = enigo.key(modifier, Direction::Press);
+            let _ = enigo.key(Key::Unicode('c'), Direction::Click);
+            let _ = enigo.key(modifier, Direction::Release);
+        });
 
         std::thread::sleep(std::time::Duration::from_millis(CLIPBOARD_COPY_SETTLE_MS));
 
@@ -513,28 +476,60 @@ impl PipelineHandle {
 
         tokio::spawn(async move {
             // Forward audio to STT and receive transcripts
+            let mut audio_chunks_sent: u64 = 0;
+            let mut audio_bytes_sent: u64 = 0;
+            let mut last_partial = String::new();
             loop {
                 tokio::select! {
                     chunk = audio_rx.recv() => {
                         match chunk {
                             Some(data) => {
-                                let _ = provider.send_audio(&data).await;
+                                audio_chunks_sent += 1;
+                                audio_bytes_sent += data.len() as u64;
+                                if audio_chunks_sent == 1 || audio_chunks_sent.is_multiple_of(100) {
+                                    tracing::debug!(
+                                        "STT audio: {} chunks sent, {} bytes total",
+                                        audio_chunks_sent, audio_bytes_sent
+                                    );
+                                }
+                                if let Err(e) = provider.send_audio(&data).await {
+                                    tracing::error!("STT send_audio error: {}", e);
+                                    break;
+                                }
                             }
                             None => {
+                                tracing::debug!(
+                                    "Audio channel closed after {} chunks ({} bytes)",
+                                    audio_chunks_sent, audio_bytes_sent
+                                );
                                 // Audio channel closed — disconnect and capture final transcript
-                                match provider.disconnect().await {
-                                    Ok(Some(text)) => {
-                                        let mut acc = accumulated.lock().unwrap_or_else(|e| e.into_inner());
-                                        acc.push_str(&text);
-                                        let current = acc.clone();
-                                        drop(acc);
-                                        let _ = app_handle.emit("stt:final", &current);
-                                    }
-                                    Ok(None) => {}
+                                let disconnect_result = provider.disconnect().await;
+                                let disconnect_text = match disconnect_result {
+                                    Ok(Some(text)) => Some(text),
+                                    Ok(None) => None,
                                     Err(e) => {
                                         tracing::error!("STT disconnect error: {}", e);
                                         let _ = app_handle.emit("pipeline:error", format!("STT error: {e}"));
+                                        None
                                     }
+                                };
+
+                                // Use disconnect text if available, otherwise use last partial
+                                let final_text = disconnect_text.unwrap_or_else(|| {
+                                    if !last_partial.is_empty() {
+                                        tracing::info!("STT using last partial: {:?}", last_partial);
+                                        last_partial.clone()
+                                    } else {
+                                        String::new()
+                                    }
+                                });
+
+                                if !final_text.is_empty() {
+                                    let mut acc = accumulated.lock().unwrap_or_else(|e| e.into_inner());
+                                    acc.push_str(&final_text);
+                                    let current = acc.clone();
+                                    drop(acc);
+                                    let _ = app_handle.emit("stt:final", &current);
                                 }
                                 break;
                             }
@@ -543,11 +538,26 @@ impl PipelineHandle {
                     transcript = provider.recv_transcript() => {
                         match transcript {
                             Ok(Some(TranscriptEvent::Partial { text })) => {
+                                tracing::debug!("STT partial: {:?}", text);
+                                last_partial = text.clone();
                                 let _ = app_handle.emit("stt:partial", &text);
                             }
                             Ok(Some(TranscriptEvent::Final { text, .. })) => {
+                                tracing::info!("STT final: {:?}", text);
+                                // Deepgram sometimes sends a truncated final that is shorter
+                                // than the last partial. If so, use the partial instead.
+                                let text_to_use = if !last_partial.is_empty() && text.len() < last_partial.len() {
+                                    tracing::warn!(
+                                        "STT final shorter than last partial, using partial: {:?}",
+                                        last_partial
+                                    );
+                                    last_partial.clone()
+                                } else {
+                                    text
+                                };
+                                last_partial.clear();
                                 let mut acc = accumulated.lock().unwrap_or_else(|e| e.into_inner());
-                                acc.push_str(&text);
+                                acc.push_str(&text_to_use);
                                 acc.push(' ');
                                 let current = acc.clone();
                                 drop(acc);
@@ -974,7 +984,7 @@ impl PipelineHandle {
             mode
         };
 
-        match output::output_with_fallback(text, effective_mode).await {
+        match output::output_with_fallback(&self.app_handle, text, effective_mode).await {
             Ok(Some(user_error)) => {
                 tracing::info!("Output fell back to clipboard");
                 let _ = self.app_handle.emit("pipeline:warning", &user_error);


### PR DESCRIPTION
## Summary

Fix crashes on macOS 26.5 caused by two incompatible API calls: `Enigo::new()` must run on the main dispatch queue, and `AXIsProcessTrustedWithOptions` crashes with a null pointer.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Changes

macOS 26.5 (25F71) introduced stricter thread safety checks in the TSM (Text Services Manager) framework. `Enigo::new()` calls `TSMCurrentKeyboardInputSourceRefCreate` which now requires the main dispatch queue. Additionally, `AXIsProcessTrustedWithOptions` crashes with `EXC_BAD_ACCESS` on macOS 26.5.

- **Enigo main thread**: Use `app_handle.run_on_main_thread()` to dispatch `Enigo::new()` and keyboard simulation to the main thread
- **AXIsProcessTrusted fix**: Replace `AXIsProcessTrustedWithOptions` FFI with `AXIsProcessTrusted()` + open System Settings to Accessibility pane
- **Audio handling**: Add debug logging for audio chunks, handle truncated STT finals by falling back to last partial

## Test Plan

- [x] Tested locally on macOS 26.5 (25F71) ARM-64
- [x] `npm run build` passes
- [x] `npx vitest run` passes (pre-existing failures in api.test.ts/authStore.test.ts unrelated to this change)
- [x] `cargo clippy -- -D warnings` passes
- [x] No regressions in existing functionality

## Screenshots / Recordings

N/A (no UI changes)

## Related Issues

Fixes `EXC_BREAKPOINT` crash in `Enigo::new()` on macOS 26.5
Fixes `EXC_BAD_ACCESS` crash in `AXIsProcessTrustedWithOptions` on macOS 26.5