### PR TITLE
fix(stt): switch DeepGram from streaming to batch mode to fix truncation

### DIFF
--- a/src-tauri/src/stt/deepgram.rs
+++ b/src-tauri/src/stt/deepgram.rs
@@ -1,16 +1,16 @@
 use async_trait::async_trait;
-use futures_util::{SinkExt, StreamExt};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use crate::error::AppError;
 
 use super::{SttConfig, SttProvider, TranscriptEvent};
 
-type WsStream =
-    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+/// Max audio buffer: ~24 MB PCM ≈ 12.5 min at 16kHz 16-bit mono.
+const MAX_AUDIO_BYTES: usize = 24 * 1024 * 1024;
 
 pub struct DeepgramProvider {
-    ws: Option<WsStream>,
+    stt_config: Option<SttConfig>,
+    audio_buffer: Vec<u8>,
+    client: reqwest::Client,
 }
 
 impl Default for DeepgramProvider {
@@ -21,147 +21,186 @@ impl Default for DeepgramProvider {
 
 impl DeepgramProvider {
     pub fn new() -> Self {
-        Self { ws: None }
+        Self {
+            stt_config: None,
+            audio_buffer: Vec::new(),
+            client: reqwest::Client::new(),
+        }
     }
 
-    fn build_url(config: &SttConfig) -> String {
-        let lang = config.language.as_deref().unwrap_or("multi");
-        format!(
-            "wss://api.deepgram.com/v1/listen?\
-             model=nova-3&\
-             smart_format={}&\
-             language={}&\
-             punctuate=true&\
-             utterances=true&\
-             interim_results=true&\
-             endpointing=150&\
-             encoding=linear16&\
-             sample_rate={}&\
-             channels=1",
-            config.smart_format, lang, config.sample_rate
-        )
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self {
+            stt_config: None,
+            audio_buffer: Vec::new(),
+            client,
+        }
+    }
+
+    /// Build a WAV file from raw PCM 16-bit mono audio.
+    fn build_wav(pcm: &[u8], sample_rate: u32) -> Vec<u8> {
+        let data_len = pcm.len() as u32;
+        let channels: u16 = 1;
+        let bits_per_sample: u16 = 16;
+        let byte_rate = sample_rate * (channels as u32) * (bits_per_sample as u32) / 8;
+        let block_align = channels * bits_per_sample / 8;
+        let file_size = 36 + data_len;
+
+        let mut wav = Vec::with_capacity(44 + pcm.len());
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&file_size.to_le_bytes());
+        wav.extend_from_slice(b"WAVE");
+        wav.extend_from_slice(b"fmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        wav.extend_from_slice(&channels.to_le_bytes());
+        wav.extend_from_slice(&sample_rate.to_le_bytes());
+        wav.extend_from_slice(&byte_rate.to_le_bytes());
+        wav.extend_from_slice(&block_align.to_le_bytes());
+        wav.extend_from_slice(&bits_per_sample.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&data_len.to_le_bytes());
+        wav.extend_from_slice(pcm);
+        wav
     }
 }
 
 #[async_trait]
 impl SttProvider for DeepgramProvider {
     async fn connect(&mut self, config: &SttConfig) -> Result<(), AppError> {
-        let url = Self::build_url(config);
+        if config.api_key.is_empty() {
+            return Err(AppError::Auth("Deepgram API key is empty".to_string()));
+        }
+        self.stt_config = Some(config.clone());
+        self.audio_buffer.clear();
+        tracing::info!("Deepgram provider ready (batch mode)");
+        Ok(())
+    }
+
+    async fn send_audio(&mut self, chunk: &[u8]) -> Result<(), AppError> {
+        if self.audio_buffer.len() + chunk.len() > MAX_AUDIO_BYTES {
+            return Err(AppError::Config(
+                "Deepgram: audio exceeds maximum length (~12 min)".to_string(),
+            ));
+        }
+        self.audio_buffer.extend_from_slice(chunk);
+        Ok(())
+    }
+
+    async fn recv_transcript(&mut self) -> Result<Option<TranscriptEvent>, AppError> {
+        // Batch mode — transcription happens in disconnect().
+        Ok(None)
+    }
+
+    async fn disconnect(&mut self) -> Result<Option<String>, AppError> {
+        let config = match &self.stt_config {
+            Some(c) => c.clone(),
+            None => return Ok(None),
+        };
+
+        if self.audio_buffer.is_empty() {
+            tracing::info!("Deepgram: no audio buffered, skipping");
+            return Ok(None);
+        }
+
+        let audio_len_secs = self.audio_buffer.len() as f64 / (config.sample_rate as f64 * 2.0);
+        let wav_data = Self::build_wav(&self.audio_buffer, config.sample_rate);
+        self.audio_buffer.clear();
+        tracing::info!(
+            "Deepgram: sending {:.1}s of audio for transcription",
+            audio_len_secs
+        );
+
+        let lang = config.language.as_deref().unwrap_or("multi");
+        let url = format!(
+            "https://api.deepgram.com/v1/listen?\
+             model=nova-3&\
+             smart_format={}&\
+             language={}&\
+             punctuate=true",
+            config.smart_format, lang
+        );
 
         let mut attempt = 0u32;
         loop {
-            let request = http::Request::builder()
-                .uri(&url)
+            let resp_result = self
+                .client
+                .post(&url)
                 .header("Authorization", format!("Token {}", config.api_key))
-                .header("Host", "api.deepgram.com")
-                .header("Connection", "Upgrade")
-                .header("Upgrade", "websocket")
-                .header("Sec-WebSocket-Version", "13")
-                .header(
-                    "Sec-WebSocket-Key",
-                    tokio_tungstenite::tungstenite::handshake::client::generate_key(),
-                )
-                .body(())
-                .map_err(|e| AppError::Config(e.to_string()))?;
+                .header("Content-Type", "audio/wav")
+                .body(wav_data.clone())
+                .timeout(std::time::Duration::from_secs(60))
+                .send()
+                .await;
 
-            match connect_async(request).await {
-                Ok((ws, _)) => {
-                    self.ws = Some(ws);
-                    tracing::info!("Deepgram WebSocket connected");
-                    return Ok(());
+            match resp_result {
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+
+                    if status.is_success() {
+                        let v: serde_json::Value = serde_json::from_str(&body)
+                            .map_err(|e| AppError::Config(e.to_string()))?;
+
+                        // DeepGram response format: results.channels[0].alternatives[0].transcript
+                        let text = v["results"]["channels"][0]["alternatives"][0]["transcript"]
+                            .as_str()
+                            .unwrap_or("")
+                            .trim()
+                            .to_string();
+
+                        tracing::info!("Deepgram transcription: {} chars", text.len());
+
+                        return Ok(if text.is_empty() {
+                            None
+                        } else {
+                            Some(text)
+                        });
+                    } else if status.as_u16() >= 500 && attempt < 2 {
+                        let truncate_at = body
+                            .char_indices()
+                            .take_while(|&(i, _)| i < 200)
+                            .last()
+                            .map(|(i, c)| i + c.len_utf8())
+                            .unwrap_or(body.len());
+                        tracing::warn!(
+                            "Deepgram server error {} (attempt {}/3): {}",
+                            status,
+                            attempt + 1,
+                            &body[..truncate_at]
+                        );
+                        attempt += 1;
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            1000 * 2u64.pow(attempt - 1),
+                        ))
+                        .await;
+                        continue;
+                    } else {
+                        let truncate_at = body
+                            .char_indices()
+                            .take_while(|&(i, _)| i < 200)
+                            .last()
+                            .map(|(i, c)| i + c.len_utf8())
+                            .unwrap_or(body.len());
+                        let sanitized = &body[..truncate_at];
+                        tracing::error!("Deepgram HTTP {}: {}", status, sanitized);
+                        return Err(AppError::Api {
+                            status: status.as_u16(),
+                            body: sanitized.to_string(),
+                        });
+                    }
                 }
-                Err(e) if attempt < 2 => {
-                    tracing::warn!("Deepgram connect failed (attempt {}/3): {}", attempt + 1, e);
+                Err(e) if e.is_timeout() && attempt < 2 => {
+                    tracing::warn!("Deepgram timeout (attempt {}/3)", attempt + 1);
                     attempt += 1;
                     tokio::time::sleep(std::time::Duration::from_millis(
                         1000 * 2u64.pow(attempt - 1),
                     ))
                     .await;
+                    continue;
                 }
-                Err(e) => return Err(AppError::Network(e.to_string())),
+                Err(e) => return Err(e.into()),
             }
         }
-    }
-
-    async fn send_audio(&mut self, chunk: &[u8]) -> Result<(), AppError> {
-        if let Some(ws) = &mut self.ws {
-            ws.send(Message::Binary(chunk.to_vec()))
-                .await
-                .map_err(|e| AppError::Network(e.to_string()))?;
-        }
-        Ok(())
-    }
-
-    async fn recv_transcript(&mut self) -> Result<Option<TranscriptEvent>, AppError> {
-        let ws = match &mut self.ws {
-            Some(ws) => ws,
-            None => return Ok(None),
-        };
-
-        match ws.next().await {
-            Some(Ok(Message::Text(text))) => {
-                let v: serde_json::Value =
-                    serde_json::from_str(&text).map_err(|e| AppError::Config(e.to_string()))?;
-
-                // Check for error
-                if v.get("type").and_then(|t| t.as_str()) == Some("Error") {
-                    let msg = v["message"].as_str().unwrap_or("Unknown error").to_string();
-                    return Ok(Some(TranscriptEvent::Error { message: msg }));
-                }
-
-                // Parse transcript
-                let transcript = v["channel"]["alternatives"][0]["transcript"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string();
-
-                if transcript.is_empty() {
-                    return Ok(None);
-                }
-
-                let is_final = v["is_final"].as_bool().unwrap_or(false);
-                let speech_final = v["speech_final"].as_bool().unwrap_or(false);
-
-                if is_final {
-                    let confidence = v["channel"]["alternatives"][0]["confidence"]
-                        .as_f64()
-                        .unwrap_or(0.0) as f32;
-
-                    if speech_final {
-                        return Ok(Some(TranscriptEvent::SpeechEnded));
-                    }
-
-                    Ok(Some(TranscriptEvent::Final {
-                        text: transcript,
-                        confidence,
-                    }))
-                } else {
-                    Ok(Some(TranscriptEvent::Partial { text: transcript }))
-                }
-            }
-            Some(Ok(Message::Close(_))) => {
-                tracing::info!("Deepgram WebSocket closed");
-                Ok(None)
-            }
-            Some(Err(e)) => {
-                tracing::error!("Deepgram WebSocket error: {}", e);
-                Ok(Some(TranscriptEvent::Error {
-                    message: e.to_string(),
-                }))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    async fn disconnect(&mut self) -> Result<Option<String>, AppError> {
-        if let Some(ws) = &mut self.ws {
-            let close_msg = serde_json::json!({"type": "CloseStream"});
-            let _ = ws.send(Message::Text(close_msg.to_string())).await;
-            let _ = ws.close(None).await;
-        }
-        self.ws = None;
-        tracing::info!("Deepgram disconnected");
-        Ok(None)
     }
 
     fn name(&self) -> &str {

--- a/src-tauri/src/stt/mod.rs
+++ b/src-tauri/src/stt/mod.rs
@@ -65,7 +65,10 @@ pub fn create_provider(
             }
         }
         "assemblyai" => Box::new(assemblyai::AssemblyAiProvider::new()),
-        "deepgram" => Box::new(deepgram::DeepgramProvider::new()),
+        "deepgram" => match client {
+            Some(c) => Box::new(deepgram::DeepgramProvider::with_client(c)),
+            None => Box::new(deepgram::DeepgramProvider::new()),
+        },
         name => {
             // All Whisper-compatible providers share the same HTTP upload logic.
             // Config is centralised in config::get_whisper_config.


### PR DESCRIPTION
## Summary

Fix DeepGram speech-to-text truncation issue by switching from streaming WebSocket mode to batch REST API mode. Long utterances were being cut short because DeepGram's streaming mode sends truncated `is_final` at sentence boundaries.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Changes

DeepGram's streaming WebSocket mode has a known issue where `is_final` transcripts can be truncated at sentence boundaries, causing long utterances to be cut short. The partial transcript before the `is_final` is often more complete than the final itself.

- **Batch mode**: Buffer all audio during recording, send as WAV via `POST /v1/listen` REST API on disconnect
- **WAV builder**: Add `build_wav()` helper to construct WAV header for raw PCM audio
- **Audio buffer limit**: Cap at ~24 MB (~12.5 min at 16kHz mono) to prevent memory issues
- **Retry logic**: Server errors (5xx) and timeouts retry up to 3 times with exponential backoff
- **Client injection**: `create_provider()` now passes `reqwest::Client` to DeepGram via `with_client()`

## Test Plan

- [x] Tested locally on macOS 26.5 (25F71) ARM-64
- [x] `npm run build` passes
- [x] `npx vitest run` passes (pre-existing failures in api.test.ts/authStore.test.ts unrelated to this change)
- [x] `cargo clippy -- -D warnings` passes
- [x] No regressions in existing functionality

## Screenshots / Recordings

N/A (no UI changes)

## Related Issues

Fixes DeepGram truncation issue where long utterances were cut short at sentence boundaries