### PR TITLE
fix: prevent macOS accessibility prompt crash

### DIFF
--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -43,6 +43,7 @@ pub fn request_accessibility_permission() -> bool {
     {
         #[link(name = "ApplicationServices", kind = "framework")]
         extern "C" {
+            fn AXIsProcessTrusted() -> u8;
             fn AXIsProcessTrustedWithOptions(options: *mut std::ffi::c_void) -> u8;
         }
         #[link(name = "CoreFoundation", kind = "framework")]
@@ -79,15 +80,23 @@ pub fn request_accessibility_permission() -> bool {
                 K_CF_STRING_ENCODING_UTF8,
             );
             let value = kCFBooleanTrue;
+            if key.is_null() || value.is_null() {
+                return AXIsProcessTrusted() != 0;
+            }
+            let keys = [key];
+            let values = [value];
 
             let options = CFDictionaryCreate(
                 std::ptr::null_mut(),
-                &[key] as *const *mut std::ffi::c_void,
-                &[value] as *const *mut std::ffi::c_void,
+                keys.as_ptr(),
+                values.as_ptr(),
                 1,
                 &kCFTypeDictionaryKeyCallBacks as *const std::ffi::c_void,
                 &kCFTypeDictionaryValueCallBacks as *const std::ffi::c_void,
             );
+            if options.is_null() {
+                return AXIsProcessTrusted() != 0;
+            }
 
             let trusted = AXIsProcessTrustedWithOptions(options);
             // options is leaked (trivial — called at most a few times)


### PR DESCRIPTION
## Summary
- Fix the macOS accessibility permission prompt path so it passes valid CoreFoundation pointer arrays to `CFDictionaryCreate`.
- Add null checks before calling `AXIsProcessTrustedWithOptions` so the app falls back to the current trust state instead of crashing.

## Root cause
The previous FFI call passed the address of a Rust slice object to `CFDictionaryCreate` instead of a pointer to the first key/value element. On macOS this could produce an invalid CFDictionary and crash inside `AXIsProcessTrustedWithOptions` / `CFGetTypeID` when requesting Accessibility permission.

## Validation
- cargo check
- Built and installed the fixed macOS app locally, then verified it launches from `/Applications/OpenTypeless.app`.

## Scope
This PR only contains the crash fix in `src-tauri/src/pipeline.rs`.