### PR TITLE
fix: initialize Xlib threading on Linux

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3298,6 +3298,7 @@ dependencies = [
  "enigo",
  "futures-util",
  "http",
+ "libloading 0.8.9",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,9 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libloading = "0.8"
+
 [profile.release]
 codegen-units = 1
 opt-level = "s"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ pub mod audio;
 pub mod commands;
 pub mod error;
 pub mod hotkey;
+#[cfg(target_os = "linux")]
+mod linux_x11;
 pub mod llm;
 pub mod output;
 pub mod pipeline;
@@ -86,6 +88,9 @@ fn apply_linux_workarounds() {
 }
 
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    let xinitthreads_status = linux_x11::init_xlib_threads();
+
     apply_linux_workarounds();
 
     tracing_subscriber::fmt()
@@ -97,6 +102,19 @@ pub fn run() {
             ),
         )
         .init();
+
+    #[cfg(target_os = "linux")]
+    match xinitthreads_status {
+        linux_x11::XInitThreadsStatus::Enabled => {
+            tracing::debug!("Initialized Xlib thread support with XInitThreads");
+        }
+        linux_x11::XInitThreadsStatus::Unavailable => {
+            tracing::debug!("libX11 unavailable; skipping XInitThreads");
+        }
+        linux_x11::XInitThreadsStatus::Failed => {
+            tracing::warn!("XInitThreads returned failure; Xlib thread support may be unavailable");
+        }
+    }
 
     tauri::Builder::default()
         .plugin(tauri_plugin_sql::Builder::default().build())

--- a/src-tauri/src/linux_x11.rs
+++ b/src-tauri/src/linux_x11.rs
@@ -1,0 +1,69 @@
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum XInitThreadsStatus {
+    Enabled,
+    Unavailable,
+    Failed,
+}
+
+pub fn init_xlib_threads() -> XInitThreadsStatus {
+    init_xlib_threads_with(|| unsafe { xinitthreads_from_libx11() })
+}
+
+fn init_xlib_threads_with(
+    load: impl FnOnce() -> Result<unsafe extern "C" fn() -> i32, libloading::Error>,
+) -> XInitThreadsStatus {
+    let Ok(xinitthreads) = load() else {
+        return XInitThreadsStatus::Unavailable;
+    };
+
+    if unsafe { xinitthreads() } == 0 {
+        XInitThreadsStatus::Failed
+    } else {
+        XInitThreadsStatus::Enabled
+    }
+}
+
+unsafe fn xinitthreads_from_libx11() -> Result<unsafe extern "C" fn() -> i32, libloading::Error> {
+    // Leak the handle intentionally: the process may later use Xlib via GTK/WebKit.
+    // Keeping libX11 loaded avoids invalidating the resolved function or Xlib state.
+    let lib = Box::leak(Box::new(unsafe { libloading::Library::new("libX11.so.6")? }));
+    let symbol = unsafe { lib.get::<unsafe extern "C" fn() -> i32>(b"XInitThreads\0")? };
+    Ok(*symbol)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    unsafe extern "C" fn xinitthreads_success() -> i32 {
+        1
+    }
+
+    unsafe extern "C" fn xinitthreads_failure() -> i32 {
+        0
+    }
+
+    #[test]
+    fn reports_enabled_when_xinitthreads_succeeds() {
+        let status = init_xlib_threads_with(|| Ok(xinitthreads_success));
+
+        assert_eq!(status, XInitThreadsStatus::Enabled);
+    }
+
+    #[test]
+    fn reports_failed_when_xinitthreads_returns_zero() {
+        let status = init_xlib_threads_with(|| Ok(xinitthreads_failure));
+
+        assert_eq!(status, XInitThreadsStatus::Failed);
+    }
+
+    #[test]
+    fn reports_unavailable_when_libx11_cannot_be_loaded() {
+        let status = init_xlib_threads_with(|| {
+            unsafe { libloading::Library::new("__opentypeless_missing_lib__.so") }
+                .map(|_| xinitthreads_success as unsafe extern "C" fn() -> i32)
+        });
+
+        assert_eq!(status, XInitThreadsStatus::Unavailable);
+    }
+}


### PR DESCRIPTION
## Summary
- Dynamically load libX11 on Linux startup and call XInitThreads before Tauri/GTK/WebKit initialization
- Keep the handle alive for the process lifetime to avoid unloading Xlib after initialization
- Add small Rust unit tests for success, failure, and unavailable-library paths

Fixes #48.

## Test plan
- npm test
- npm run build
- Attempted Rust checks via cargo, but this machine does not have cargo/rustc/rustfmt installed; the change is limited to Linux-gated Rust code and should be covered by repository CI.