### PR TITLE
fix: stabilize Linux and macOS release paths

### DIFF
--- a/docs/2026-06-13-platform-release-stabilization-spec.md
+++ b/docs/2026-06-13-platform-release-stabilization-spec.md
@@ -1,0 +1,483 @@
+# Platform Release Stabilization Spec
+
+Date: 2026-06-13
+Target release: next patch release after v0.1.34, tentatively v0.1.35
+Status: implemented locally, release pending
+
+## Executive Summary
+
+当前 v0.1.34 之后的高风险问题确实主要集中在 macOS 和 Ubuntu/Linux，Windows 暂时没有新的平台级 blocker。
+
+结论依据如下：
+
+1. Windows: 当前 main 的前端测试、类型检查、lint、format 和 build 均通过。Open issues 里唯一明确来自 Windows 的 #50 是 v0.1.27 的 LLM polish 行为问题，main 已经有更强的 prompt 隔离；#51 是 STT/TTS 配置诉求或术语混淆，不是 Windows 平台崩溃。当前不应为了 stale PR 里的 Windows 改动主动重写 Windows 输入链路。
+2. Ubuntu/Linux: #48 是 v0.1.34 上明确可复现的 Ubuntu 22.04 MATE/X11 崩溃，日志指向 `xcb_xlib_threads_sequence_lost` 和缺少 `XInitThreads`。这是当前最明确的 release blocker。
+3. macOS: #42/#43 都围绕 macOS 选中文本复制、中文输入法、Accessibility 权限、Enigo 主线程兼容性。当前 main 仍在后台线程创建 Enigo 并使用 `AXIsProcessTrustedWithOptions` 请求权限，因此 macOS 仍是高风险区。
+4. 跨平台/依赖: #33 无法安装依赖；`npm audit --audit-level=high` 当前仍有 high/critical 前端依赖漏洞。这不是某个平台独有，但会影响 release 质量门禁。
+
+本 spec 的策略是：先修最小平台 blocker，保护 Windows 稳定路径，不直接合并过期/混合 PR；再按独立 PR 处理 Deepgram、依赖审计和非 blocker feature。
+
+## Verified Baseline
+
+在当前 main 上已经完成的本地验证：
+
+1. `npm ci`: pass
+2. `npm test`: pass, 117 tests
+3. `npx tsc --noEmit`: pass
+4. `npm run lint`: pass with existing warnings
+5. `npm run format:check`: pass
+6. `npm run build`: pass
+7. `npm audit --audit-level=high --json`: fail, 10 vulnerabilities, including high and critical findings around Vite/Vitest/better-auth dependency graph
+8. `cargo`/`rustc`: local machine unavailable, Rust checks must run in CI or on machines with Rust toolchain
+
+Repository state at review time:
+
+1. Branch: `main`
+2. Remote: `origin/main`
+3. Current tag on main: `v0.1.34`
+4. Latest commit reviewed: `99a63e0`
+5. GitHub status/workflow data returned no runs for that commit, consistent with Actions/billing being blocked or unavailable.
+
+## Local Implementation Results
+
+Implemented on branch `fix/platform-release-v0.1.35`:
+
+1. Added Linux-only early `XInitThreads` initialization before Tauri/GTK/WebKit startup.
+2. Replaced macOS Accessibility prompt FFI with opening the macOS Accessibility settings pane.
+3. Changed macOS selected-text Cmd+C simulation to `/usr/bin/osascript` while preserving Windows/Linux Enigo Ctrl+C behavior.
+4. Routed macOS keyboard output through Tauri `run_on_main_thread` with oneshot acknowledgement and bounded timeout.
+5. Kept Windows/Linux keyboard output on the existing `spawn_blocking` Enigo path.
+6. Updated dependency ranges and lockfile to clear npm high/critical audit findings without adopting ESLint 10.
+
+Local verification completed:
+
+1. `npm ci`: pass
+2. `npx tsc --noEmit`: pass
+3. `npm run lint`: pass with the existing 3 warnings
+4. `npm run format:check`: pass
+5. `npx prettier --check docs/2026-06-13-platform-release-stabilization-spec.md`: pass
+6. `npm test`: pass, 117 tests
+7. `npm run build`: pass
+8. `npm audit --audit-level=high`: pass, 0 vulnerabilities
+9. `cargo fmt --check --manifest-path src-tauri/Cargo.toml`: pass
+10. `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`: pass
+11. `cargo test --manifest-path src-tauri/Cargo.toml`: pass, 110 Rust tests
+12. `git diff --check`: pass
+13. `npm run tauri -- build`: pass on local macOS aarch64, producing:
+    - `src-tauri/target/release/bundle/macos/OpenTypeless.app`
+    - `src-tauri/target/release/bundle/dmg/OpenTypeless_0.1.0_aarch64.dmg`
+
+Remaining release work:
+
+1. Run the full matrix on GitHub Actions or equivalent machines: Windows, macOS x64, macOS arm64, Ubuntu 22.04.
+2. Manually verify #48 on Ubuntu 22.04 MATE/X11.
+3. Manually verify macOS Accessibility, selected text, Chinese IME, keyboard output, and clipboard fallback.
+4. Publish a tagged release only after the repository owner billing/Actions path is working or after an explicitly approved self-hosted/local-artifact workaround.
+
+## Open Issue Triage
+
+| Item                                                                       | Platform                    | Severity | Current conclusion                                                                                                                                                                                                                  | Required action                                                                                                 |
+| -------------------------------------------------------------------------- | --------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| #48 Crash on Ubuntu 22.04 MATE/X11 with `xcb_xlib_threads_sequence_lost`   | Ubuntu/Linux X11            | P0       | Real v0.1.34 blocker. Root cause is likely Xlib/XCB thread initialization order before GTK/WebKit/Tauri touch X11.                                                                                                                  | Integrate targeted `XInitThreads` fix from #55, then verify on Ubuntu 22.04 MATE/X11.                           |
+| #50 Polish LLM punctuation/list numbering/instruction execution in Spanish | Windows report, logic-level | P1/P2    | Report was on v0.1.27. Current main already strengthened prompt by marking transcription/selected text as untrusted. Punctuation and duplicate numbering still need regression tests because model output remains nondeterministic. | Add deterministic prompt/unit coverage and manual Spanish regression; do not treat as Windows platform blocker. |
+| #51 Local TTS model URL on Windows client                                  | Windows UI/config request   | P2       | Product is STT-focused; current main already supports Local/Custom Whisper STT config. If user literally means TTS, that is a new feature outside current release stabilization.                                                    | Reply/clarify in issue after review. No release-blocking code change unless missing STT UI is confirmed.        |
+| #28 Summary UI and Doubao API compatibility                                | Cross-platform feature      | P3       | Feature request, not release blocker.                                                                                                                                                                                               | Defer until after platform stabilization.                                                                       |
+
+## Open PR Triage
+
+| PR                                                           | Platform/scope                                | Merge decision                                     | Detailed reason                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------ | --------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #55 `fix: initialize Xlib threading on Linux`                | Ubuntu/Linux                                  | Accept as base, after validation                   | This is the targeted fix for #48. It adds Linux-only `libloading`, loads `libX11.so.6`, resolves `XInitThreads`, calls it at the start of `run()`, and intentionally keeps the library handle alive. Needs Rust/CI and Ubuntu X11 smoke verification. |
+| #52 `feat: add macos microphone input selector`              | Audio device selection, mostly UI/Rust config | Defer from blocker release or merge after P0 fixes | Useful feature but not crash fix. Uses CPAL device names as stable IDs, which can collide or change. UI appears cross-platform despite macOS title. Needs device-list tests and manual selection tests before release inclusion.                      |
+| #53 `Added 60dB integration`                                 | New STT provider                              | Defer or require rewrite                           | `sixtydb_probe` appears to treat only HTTP success as valid API-key proof while comments say silent audio may be rejected as low-SNR/no credits. Empty PR checklist. Needs API-doc confirmation and provider integration tests.                       |
+| #47 `feat: add local custom whisper stt`                     | Custom local STT                              | Close/supersede                                    | Main already contains Local/Custom Whisper. The PR is stale and conflicts with main in config, settings, onboarding, locales, constants, and store. Only cherry-pick docs/tests if something is still missing.                                        |
+| #45 `fix: consolidate platform stability regressions`        | Mixed platform/deps/STT/tray                  | Do not merge                                       | Large stale mixed PR with conflicts. It combines unrelated changes and risks destabilizing Windows/Linux/macOS together. Extract only independently reviewed fixes into focused branches.                                                             |
+| #44 `fix(stt): switch DeepGram from streaming to batch mode` | Deepgram STT                                  | Rebuild before merge                               | Current PR has a hot-loop/starvation bug: batch `recv_transcript()` returns `Ok(None)` immediately. It also conflicts with main. Fix must make file/batch providers await pending work instead of returning an immediately-ready no-op future.        |
+| #43 `fix(mac): move Enigo::new() to main thread`             | macOS input/output                            | Rebuild, do not direct-merge                       | Direction is relevant for macOS, but current implementation routes all platforms through Tauri main thread, blocks on `std::sync::mpsc::recv()` inside async methods, ignores `run_on_main_thread` scheduling failure, and risks clipboard race.      |
+| #42 `fix(mac): use osascript for Cmd+C`                      | macOS selected-text copy                      | Rebuild as macOS-only fix                          | The merge is conflict-free but changes non-mac selected-text capture behavior to a queued main-thread Enigo path. The title says macOS only, so Windows/Linux behavior must remain unchanged.                                                         |
+| #33 Dependabot dev group                                     | Frontend dependencies                         | Do not merge                                       | `npm ci` fails with peer dependency conflict: `eslint@10.2.0` is incompatible with current `eslint-plugin-react-hooks` peer range. Use targeted dependency bumps instead.                                                                             |
+| #10 tokio 1.49 to 1.50                                       | Rust dependency                               | Optional after CI                                  | Low-risk lockfile-only update, but local Rust is unavailable. Gate on `cargo test`, `cargo clippy`, and platform CI.                                                                                                                                  |
+| #9 setup-node v4 to v6                                       | CI/release action                             | Optional after Actions health restored             | Low-risk workflow action bump. Not useful until Actions/billing path is healthy.                                                                                                                                                                      |
+| #8 semantic-pull-request v5 to v6                            | PR-title workflow                             | Optional after Actions health restored             | Low-risk, but should wait until CI can run reliably.                                                                                                                                                                                                  |
+
+## Release Goals
+
+1. Fix the Ubuntu 22.04 MATE/X11 startup crash without changing Windows behavior.
+2. Stabilize macOS text capture/output and Accessibility permission flow without moving Linux/Windows onto new input primitives.
+3. Keep the release scoped: no broad mixed PR, no stale conflict-heavy merge, no feature PR unless it has direct release value.
+4. Restore a trustworthy release pipeline despite current account billing constraints.
+5. Reduce high/critical dependency audit findings or document any unavoidable exception before publishing.
+
+## Non-Goals
+
+1. Do not redesign STT provider architecture in this release.
+2. Do not implement the summary UI from #28.
+3. Do not add literal TTS support unless #51 is confirmed to be about text-to-speech rather than local/custom speech-to-text.
+4. Do not rewrite Windows keyboard hooks or output unless a new Windows-specific reproduction appears.
+5. Do not merge PR #45 as a bundle.
+
+## Implementation Plan
+
+### Phase 1: Branch Hygiene and PR Disposition
+
+Create a fresh branch from current `main`, for example:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b fix/platform-release-v0.1.35
+```
+
+PR decisions before coding:
+
+1. Mark #55 as the source for the Linux/X11 fix.
+2. Close or supersede #47 because main already contains local/custom STT.
+3. Close or replace #33 because it cannot install dependencies.
+4. Do not merge #45; reference it only as historical context.
+5. Rebuild #42/#43 as focused macOS changes.
+6. Rebuild #44 separately or defer it if the platform release must stay narrow.
+7. Defer #52/#53/#8/#9/#10 unless there is enough CI capacity after P0 fixes.
+
+### Phase 2: Ubuntu/Linux X11 Crash Fix
+
+Target files:
+
+1. `src-tauri/Cargo.toml`
+2. `src-tauri/Cargo.lock`
+3. `src-tauri/src/lib.rs`
+4. `src-tauri/src/linux_x11.rs` as a new Linux-only module
+
+Required behavior:
+
+1. On Linux only, call `XInitThreads()` before any GTK, WebKit, Tauri builder, window, tray, plugin, tracing subscriber side effect, or X11/XCB consumer is initialized.
+2. Load `libX11.so.6` dynamically using a Linux-only dependency such as `libloading`.
+3. Resolve `XInitThreads` with signature `unsafe extern "C" fn() -> std::ffi::c_int`.
+4. If the library cannot be loaded or the symbol cannot be resolved, log a warning and continue. Do not hard-crash on Wayland-only systems or minimal environments.
+5. If `XInitThreads()` returns 0, log a warning and continue. Treat it as degraded startup, not fatal.
+6. Keep the loaded X11 library handle alive for the process lifetime after resolving/calling the symbol.
+7. Preserve the existing NVIDIA + Wayland DMA-BUF workaround and run it after the Xlib thread initialization.
+8. Do not modify Windows or macOS startup paths.
+
+Tests and verification:
+
+1. Add unit tests around Linux helper status mapping where possible without requiring X11 at test time.
+2. CI: `cargo fmt --check --manifest-path src-tauri/Cargo.toml`.
+3. CI: `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`.
+4. CI: `cargo test --manifest-path src-tauri/Cargo.toml`.
+5. Manual Ubuntu 22.04 MATE/X11: launch installed app or AppImage from terminal; confirm no `xcb_xlib_threads_sequence_lost`.
+6. Manual Ubuntu 22.04 MATE/X11: start/stop recording, verify tray/menu still works.
+7. Manual Ubuntu Wayland: app should still launch; keyboard output may fall back according to existing Wayland guardrails.
+8. Manual Linux without `xdotool`: confirm user-visible fallback/warning still behaves as before.
+
+Acceptance criteria:
+
+1. #48 reproduction no longer crashes on startup.
+2. No behavior change on Windows.
+3. No behavior change on macOS startup.
+4. Linux startup logs show Xlib threading was initialized or clearly explain why it was skipped.
+
+### Phase 3: macOS Accessibility Permission Stability
+
+Current risk:
+
+1. `request_accessibility_permission()` calls `AXIsProcessTrustedWithOptions` and manually builds a CoreFoundation dictionary.
+2. PR #43 indicates this path can crash on newer macOS versions.
+3. The existing implementation leaks CoreFoundation objects and uses unsafe FFI directly.
+
+Required behavior:
+
+1. Keep `is_accessibility_trusted()` using `AXIsProcessTrusted()`.
+2. Replace the prompt path with a safer flow inside the existing
+   `request_accessibility_permission()` Tauri command:
+   - Check `AXIsProcessTrusted()`.
+   - If not trusted, open System Settings to the Accessibility Privacy pane using
+     `/usr/bin/open x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility`.
+   - Return `false` so the frontend can show the existing permission-needed state.
+3. Do not call `AXIsProcessTrustedWithOptions` in the release fix unless it is wrapped safely with correct CoreFoundation ownership and tested on the affected macOS version.
+4. Do not request permission repeatedly in a loop.
+5. Keep non-macOS behavior as `true`.
+
+Manual verification:
+
+1. macOS with permission absent: app opens the correct Settings pane and does not crash.
+2. macOS after permission granted: `is_accessibility_trusted()` returns true and recording/output works.
+3. macOS after permission revoked: app returns to permission-needed state without crashing.
+
+Acceptance criteria:
+
+1. No crash during permission request on macOS.
+2. User can recover by granting Accessibility permission.
+3. Linux and Windows permission paths remain unchanged.
+
+### Phase 4: macOS Selected Text Capture
+
+Current main behavior:
+
+1. `capture_selected_text()` backs up clipboard.
+2. It writes a sentinel.
+3. It uses Enigo to send Cmd+C on macOS or Ctrl+C elsewhere.
+4. It sleeps for clipboard settle time.
+5. It restores the clipboard and ignores the sentinel.
+
+Risk:
+
+1. On macOS, Enigo Cmd+C can conflict with Chinese IME or be unreliable.
+2. PR #42 uses `osascript`, which is directionally correct, but its merge result changes non-mac behavior.
+
+Required behavior:
+
+1. On macOS only, send Cmd+C through `/usr/bin/osascript`:
+
+```applescript
+tell application "System Events" to keystroke "c" using command down
+```
+
+2. Keep the sentinel clipboard protection exactly as main has it.
+3. Keep the clipboard backup/restore behavior exactly as main has it.
+4. Keep Windows/Linux direct Enigo Ctrl+C behavior unchanged unless a separate platform bug is reproduced.
+5. If `osascript` fails, log the failure and either:
+   - return `None`, or
+   - fall back to a macOS-only main-thread Enigo helper with acknowledgement and timeout.
+6. If a fallback helper is added, it must:
+   - report scheduling failure from `run_on_main_thread`,
+   - send completion over a oneshot channel,
+   - have a bounded timeout,
+   - never block the async runtime indefinitely,
+   - never sleep and assume the main-thread action already ran.
+
+Manual verification:
+
+1. macOS with English input method: selected text is captured and clipboard is restored.
+2. macOS with Chinese input method active: selected text is captured and no stray character/composition is inserted.
+3. macOS with no selected text: sentinel is ignored and stale clipboard is not treated as context.
+4. Windows: Ctrl+C selected-text capture behavior is unchanged.
+5. Ubuntu/X11: Ctrl+C selected-text capture behavior is unchanged.
+
+Acceptance criteria:
+
+1. macOS selected-text capture becomes more reliable.
+2. No Windows/Linux selected-text regression.
+3. Clipboard restore behavior remains deterministic.
+
+### Phase 5: macOS Keyboard Output Main-Thread Safety
+
+Current main behavior:
+
+1. `KeyboardOutput::type_text()` uses `tokio::task::spawn_blocking`.
+2. It creates `Enigo` in that worker thread.
+3. It chunks text and sends keyboard events.
+
+Risk:
+
+1. PR #43 suggests `Enigo::new()` or CGEvent usage can be unsafe off main thread on newer macOS.
+2. Directly moving all platforms to Tauri main thread is too risky.
+3. Blocking on `std::sync::mpsc::recv()` inside async code can freeze or starve execution.
+
+Required behavior:
+
+1. On macOS only, route Enigo creation and key/text events through a helper that runs on the Tauri main thread.
+2. Preserve existing Windows/Linux `spawn_blocking` implementation.
+3. The macOS helper must:
+   - accept an `AppHandle` or main-thread dispatcher explicitly,
+   - return a structured `Result<(), AppError>`,
+   - acknowledge scheduling success/failure,
+   - use a bounded timeout for scheduling/completion,
+   - avoid holding locks across main-thread callbacks,
+   - chunk long text using the current `TYPE_CHUNK_SIZE`,
+   - preserve Shift+Return line break behavior.
+4. Use the smallest explicit-context design:
+   - pass `&tauri::AppHandle` into `output::output_with_fallback(...)`,
+   - pass the same handle into `output::create_output(...)`,
+   - let `KeyboardOutput` clone/store the handle only under `#[cfg(target_os = "macos")]`,
+   - keep `ClipboardOutput` unchanged.
+5. Avoid a global dispatcher or singleton for this release.
+
+Manual verification:
+
+1. macOS 26.5 or affected version: keyboard output no longer crashes.
+2. macOS: long multi-line output is typed with correct line breaks.
+3. macOS: output failure falls back to clipboard through `output_with_fallback()`.
+4. Windows: keyboard output still works through existing path.
+5. Ubuntu/X11: keyboard output still works through existing path.
+
+Acceptance criteria:
+
+1. macOS no longer creates Enigo off-main-thread for keyboard output.
+2. Windows/Linux code path remains unchanged.
+3. Failure fallback to clipboard still works.
+
+### Phase 6: Deepgram Batch PR Decision
+
+This phase is optional for the platform patch unless Deepgram truncation is currently release-critical.
+
+Known issue in #44:
+
+1. Batch `recv_transcript()` returns `Ok(None)` immediately.
+2. The pipeline waits on providers using `tokio::select!`.
+3. An immediately-ready `Ok(None)` branch can spin or starve real work.
+
+Required behavior if included:
+
+1. Rebase/rebuild against current main.
+2. For file/batch providers, make `recv_transcript()` await forever or await a cancellation-aware pending future after upload finalization is handled elsewhere.
+3. Prefer reusing shared WAV-building logic where possible rather than duplicating fragile audio serialization.
+4. Preserve Custom Whisper and hosted STT provider creation behavior from main.
+5. Add a regression test that proves batch provider receive does not hot-loop.
+
+Acceptance criteria if included:
+
+1. Deepgram no longer truncates due to streaming finalization behavior.
+2. Pipeline CPU does not spike after recording stop.
+3. Custom Whisper and other STT providers still pass existing tests.
+
+### Phase 7: Dependency and Security Hardening
+
+Current risk:
+
+1. `npm audit --audit-level=high` fails.
+2. #33 cannot be merged because of ESLint 10 peer dependency conflicts.
+3. CI audit currently uses `continue-on-error: true`, so high/critical findings are visible but not blocking.
+
+Required behavior:
+
+1. Do not merge #33.
+2. Apply targeted dependency updates instead:
+   - update `vitest` to a patched version at or above the audit-safe range,
+   - update `vite` to a patched version beyond the affected range,
+   - update `better-auth` to the audit-safe range,
+   - keep `eslint` on v9 unless all plugins explicitly support v10.
+3. Run `npm ci` after lockfile changes.
+4. Run the full frontend suite:
+   - `npx tsc --noEmit`
+   - `npm run lint`
+   - `npm run format:check`
+   - `npm test`
+   - `npm run build`
+5. Re-run `npm audit --audit-level=high`.
+6. If an audit finding cannot be fixed without a large upgrade, document:
+   - package,
+   - severity,
+   - reachable or not reachable,
+   - why it is accepted for this release,
+   - target follow-up version.
+7. After audit is clean or exceptions are documented, consider changing the CI high audit step from `continue-on-error: true` to blocking in a separate focused PR.
+
+Acceptance criteria:
+
+1. No dependency install conflict.
+2. No high/critical audit finding remains, or each has an explicit release exception.
+3. No broad tooling upgrade destabilizes the release.
+
+### Phase 8: CI and Release Workflow
+
+Current workflow facts:
+
+1. Release workflow builds Windows, macOS arm64, macOS x64, and Ubuntu 22.04.
+2. Release workflow can be triggered by tag push or `workflow_dispatch` with tag input.
+3. Release workflow uses `GITHUB_TOKEN`.
+4. GitHub-hosted Actions billing is tied to the repository owner/account/organization, not merely the local `gh` login.
+
+Important billing conclusion:
+
+Switching the local GitHub CLI account alone will not fix GitHub-hosted Actions if the repository owner's billing is blocked. To publish through GitHub-hosted runners, the repository owner billing must be healthy, or the build must run under a repository/account/organization with working Actions entitlement.
+
+Release paths:
+
+1. Preferred path after billing is fixed:
+   - push final branch,
+   - merge after CI,
+   - create tag `v0.1.35` or the chosen next version,
+   - run Release workflow,
+   - verify draft release assets,
+   - publish draft.
+2. Billing workaround path:
+   - use an alternate account only if it has admin/write access and a repository context where Actions can run,
+   - transfer/fork temporarily only if acceptable for project ownership and release provenance,
+   - or use a self-hosted runner/local builds and upload assets to the original release with a token that has `contents:write`.
+3. Re-publish with current account after billing is fixed:
+   - do not create a second tag with the same version,
+   - keep or recreate the same tag intentionally,
+   - delete or replace draft assets if they were built by a workaround path,
+   - rerun the Release workflow from the original repository owner context,
+   - compare asset names, checksums, and app version metadata before publishing.
+
+Release asset acceptance criteria:
+
+1. Windows installer is present.
+2. macOS arm64 artifact is present.
+3. macOS x64 artifact is present.
+4. Linux AppImage/deb/rpm artifacts expected by Tauri action are present.
+5. About/version UI displays the release tag through `VITE_APP_VERSION`.
+6. `src-tauri/tauri.conf.json`, `package.json`, and `src-tauri/Cargo.toml` are synced by workflow to the tag version.
+
+## Platform Verification Matrix
+
+| Platform                 | Required for release | Test focus                                                                                                                                      |
+| ------------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows 11 x64           | Smoke required       | Ensure no regression: install, launch, hotkey, selected text, keyboard output, clipboard fallback, STT/LLM happy path.                          |
+| macOS Apple Silicon      | Required             | Accessibility permission, selected text with English and Chinese IME, keyboard output, clipboard fallback, long multiline output, app relaunch. |
+| macOS Intel              | Strongly recommended | Same as Apple Silicon, because release builds both architectures.                                                                               |
+| Ubuntu 22.04 MATE/X11    | Required             | #48 reproduction, app launch, tray, recording, selected text, keyboard output, no XCB thread crash.                                             |
+| Ubuntu Wayland           | Recommended          | Launch stability, NVIDIA DMA-BUF workaround, keyboard unavailable/fallback messaging.                                                           |
+| Ubuntu without `xdotool` | Recommended          | Existing guardrail still reports/falls back cleanly.                                                                                            |
+
+## Final Release Checklist
+
+Code and tests:
+
+1. `git status --short` shows only intentional files.
+2. `npm ci` passes.
+3. `npx tsc --noEmit` passes.
+4. `npm run lint` passes.
+5. `npm run format:check` passes.
+6. `npm test` passes.
+7. `npm run build` passes.
+8. `npm audit --audit-level=high` passes or has documented exceptions.
+9. `cargo fmt --check --manifest-path src-tauri/Cargo.toml` passes.
+10. `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` passes.
+11. `cargo test --manifest-path src-tauri/Cargo.toml` passes.
+12. Release workflow or equivalent local/self-hosted build produces all target assets.
+
+Issue and PR hygiene:
+
+1. #48 references the Linux/X11 fix and asks reporter to verify.
+2. #55 is merged or superseded by the focused Linux fix PR.
+3. #42/#43 are superseded by focused macOS fix PR(s).
+4. #44 is either fixed separately or explicitly deferred.
+5. #47 is closed/superseded.
+6. #45 is closed/superseded as too broad.
+7. #33 is closed/superseded due to dependency conflict.
+8. #50 has a note explaining what was already fixed and what regression coverage was added or deferred.
+9. #51 has a clarification reply distinguishing STT local/custom URL from literal TTS.
+10. #28 remains deferred as feature work.
+
+Manual sign-off:
+
+1. Windows smoke test signed off.
+2. macOS Apple Silicon signed off.
+3. macOS Intel signed off or explicitly marked not available.
+4. Ubuntu 22.04 MATE/X11 signed off.
+5. Release artifacts installed and launched on at least one clean machine per OS family.
+
+## Risk Register
+
+| Risk                                                        | Impact                       | Mitigation                                                                                                                   |
+| ----------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Linux `XInitThreads` is called too late                     | #48 remains unfixed          | Call helper at the first line of `run()` before tracing/Tauri/plugins.                                                       |
+| macOS main-thread helper deadlocks                          | App freeze during output     | Use oneshot acknowledgement and timeout; never block async code on unbounded `recv()`.                                       |
+| macOS fix accidentally changes Windows/Linux Enigo behavior | Windows/Linux regression     | Use `#[cfg(target_os = "macos")]` boundaries and smoke-test Windows/Linux.                                                   |
+| Dependency bump pulls ESLint 10 again                       | `npm ci` fails               | Keep ESLint 9 unless peer ranges prove support.                                                                              |
+| Billing workaround creates untrusted artifacts              | Release provenance confusion | Prefer original repository workflow after billing fix; otherwise document build machine, commit, checksums, and token scope. |
+| Deepgram batch work expands release scope                   | Delayed platform fix         | Defer #44 unless it is confirmed as release-critical.                                                                        |
+
+## Recommended Execution Order
+
+1. Land Linux #48/#55 targeted fix.
+2. Land macOS Accessibility permission fix.
+3. Land macOS selected text Cmd+C fix.
+4. Land macOS keyboard output main-thread safety fix.
+5. Run dependency audit targeted bumps.
+6. Run full CI and platform manual matrix.
+7. Decide whether Deepgram #44 is in or out for the patch.
+8. Prepare release tag and draft release through the billing-safe path.
+9. Once current account billing is healthy, rebuild/re-publish from the original repository context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tauri-apps/plugin-opener": "^2.2",
         "@tauri-apps/plugin-sql": "^2.2",
         "@tauri-apps/plugin-store": "^2.2",
-        "better-auth": "^1.3",
+        "better-auth": "^1.6.17",
         "framer-motion": "^11.18",
         "i18next": "^24.2",
         "lucide-react": "^0.460",
@@ -42,8 +42,8 @@
         "tailwindcss": "^4.1",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.22",
-        "vite": "^7.0.4",
-        "vitest": "^3.0"
+        "vite": "^7.3.5",
+        "vitest": "^3.2.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -57,7 +57,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
       "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -71,7 +71,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
@@ -366,50 +366,143 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.4.19",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.19.tgz",
-      "integrity": "sha512-uADLHG1jc5BnEJi7f6ijUN5DmPPRSj++7m/G19z3UqA3MVCo4Y4t1MMa4IIxLCqGDFv22drdfxescgW+HnIowA==",
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.17.tgz",
+      "integrity": "sha512-ithzeL/IKsBEYeCDJs9r1KE2nwYC/6ni8oMA8NCCtP18RoCOiWErFSjrnL+XLaN6zxrB0ko7QxREjyzTNBtusQ==",
+      "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "zod": "^4.3.5"
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "better-call": "1.1.8",
+        "@better-auth/utils": "0.4.1",
+        "@better-fetch/fetch": "1.3.0",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.6",
         "jose": "^6.1.0",
-        "kysely": "^0.28.5",
+        "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.17.tgz",
+      "integrity": "sha512-Dq52cdZ0vREalUwbP8GXBbpk7XTSw5rZtY8n3nTTwrU09RELsXTi0oYQRW62MFYaUqw0mCHIT4H0emAH/5hy5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.17",
+        "@better-auth/utils": "0.4.1",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.17.tgz",
+      "integrity": "sha512-rhDrpzyGtogEDrJ3Id+nbOUVtT1DxMF9OFl2EwyktUuvTFyCrefClBdvVbmeYZPva9+ERuOsbjma+E9E0SJ0RA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.17",
+        "@better-auth/utils": "0.4.1",
+        "kysely": "^0.28.17 || ^0.29.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.17.tgz",
+      "integrity": "sha512-7oU+Gkve7RivIfQkclIet8+qJON6tbbRINihmgGoi67uGPTeEdTy2UixF8R8+lv91gI/Aqea2oNg/MKIalhlIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.17",
+        "@better-auth/utils": "0.4.1"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.17.tgz",
+      "integrity": "sha512-nSmolHUVR2/AIKg6WijrSxdF9DCAybbiswulw9ph4FghuCuWl9DDzfTKvG/z+/FpRaYuY+KYFitNbeRiTonn1A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.17",
+        "@better-auth/utils": "0.4.1",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.17.tgz",
+      "integrity": "sha512-DW1eEXw39Hv/z34ctfoR6lB3rZRt/+X/m7j74dYTsSUt7TjaIjfhQkN01mYN7+GeLSqzGxJ132N93L7iGutKuA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.17",
+        "@better-auth/utils": "0.4.1",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.4.19",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.19.tgz",
-      "integrity": "sha512-ApGNS7olCTtDpKF8Ow3Z+jvFAirOj7c4RyFUpu8axklh3mH57ndpfUAUjhgA8UVoaaH/mnm/Tl884BlqiewLyw==",
-      "dependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21"
-      },
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.17.tgz",
+      "integrity": "sha512-ik7gC4UgdR3Jyb0x7yVzLTfc04x5kfjFbSdOraUbhZUXkOF+/7Ee57SuB2QgfffGEr8xhGHp46sqzF9u2D4qoQ==",
+      "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.4.19"
+        "@better-auth/core": "^1.6.17",
+        "@better-auth/utils": "0.4.1",
+        "@better-fetch/fetch": "1.3.0"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.1.tgz",
+      "integrity": "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.0.tgz",
+      "integrity": "sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A==",
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
       "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -429,7 +522,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -453,7 +546,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
       "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -481,7 +574,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -504,7 +597,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -527,7 +620,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -544,7 +636,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -561,7 +652,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -578,7 +668,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -595,7 +684,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -612,7 +700,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -629,7 +716,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -646,7 +732,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,7 +748,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -680,7 +764,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,7 +780,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -714,7 +796,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -731,7 +812,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -748,7 +828,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,7 +844,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -782,7 +860,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,7 +876,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -816,7 +892,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,7 +908,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -850,7 +924,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -867,7 +940,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,7 +956,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,7 +972,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,7 +988,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -935,7 +1004,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,7 +1020,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1232,6 +1299,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1246,7 +1322,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1260,7 +1335,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1274,7 +1348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1288,7 +1361,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,7 +1374,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1316,7 +1387,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1400,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,7 +1413,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,7 +1426,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1372,7 +1439,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1386,7 +1452,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1400,7 +1465,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1414,7 +1478,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1428,7 +1491,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1442,7 +1504,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1456,7 +1517,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1470,7 +1530,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1484,7 +1543,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1498,7 +1556,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1512,7 +1569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1526,7 +1582,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1540,7 +1595,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1554,7 +1608,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1568,7 +1621,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1582,7 +1634,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,9 +2579,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2646,15 +2697,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2663,13 +2714,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2690,9 +2741,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2703,13 +2754,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -2718,13 +2769,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2733,9 +2784,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2746,13 +2797,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -2787,7 +2838,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2868,7 +2919,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/balanced-match": {
@@ -2892,23 +2943,28 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.4.19",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.19.tgz",
-      "integrity": "sha512-3RlZJcA0+NH25wYD85vpIGwW9oSTuEmLIaGbT8zg41w/Pa2hVWHKedjoUHHJtnzkBXzDb+CShkLnSw7IThDdqQ==",
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.17.tgz",
+      "integrity": "sha512-M0XMJ9/KE9hlmuN2Zha1VayShZW5CQifAMPaoz41gtao2la6YpT5KrnL5MAeIAM/3d4DkdYA2BVMY1Gt4iEzHw==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.4.19",
-        "@better-auth/telemetry": "1.4.19",
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@noble/ciphers": "^2.0.0",
-        "@noble/hashes": "^2.0.0",
-        "better-call": "1.1.8",
+        "@better-auth/core": "1.6.17",
+        "@better-auth/drizzle-adapter": "1.6.17",
+        "@better-auth/kysely-adapter": "1.6.17",
+        "@better-auth/memory-adapter": "1.6.17",
+        "@better-auth/mongo-adapter": "1.6.17",
+        "@better-auth/prisma-adapter": "1.6.17",
+        "@better-auth/telemetry": "1.6.17",
+        "@better-auth/utils": "0.4.1",
+        "@better-fetch/fetch": "1.3.0",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.6",
         "defu": "^6.1.4",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1",
-        "zod": "^4.3.5"
+        "jose": "^6.1.3",
+        "kysely": "^0.28.17 || ^0.29.0",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
         "@lynx-js/react": "*",
@@ -2918,7 +2974,7 @@
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -2992,15 +3048,15 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
-      "integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.6.tgz",
+      "integrity": "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.3.0",
-        "@better-fetch/fetch": "^1.1.4",
-        "rou3": "^0.7.10",
-        "set-cookie-parser": "^2.7.1"
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -3012,9 +3068,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3070,7 +3126,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3179,7 +3235,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3228,7 +3284,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
       "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -3242,7 +3298,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -3256,7 +3312,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -3288,7 +3344,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3309,16 +3365,16 @@
       "license": "MIT"
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3338,7 +3394,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3356,7 +3412,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3392,7 +3448,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3405,7 +3461,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3415,7 +3471,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3432,7 +3488,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3445,7 +3501,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3803,9 +3859,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3813,7 +3869,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3857,7 +3913,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3872,7 +3927,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3892,7 +3947,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3917,7 +3972,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3957,7 +4012,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3987,7 +4042,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4000,7 +4055,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4016,7 +4071,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4029,7 +4084,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
       "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -4051,7 +4106,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -4065,7 +4120,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -4110,7 +4165,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4193,7 +4248,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4207,16 +4262,16 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -4246,7 +4301,7 @@
       "version": "25.0.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.1.0",
@@ -4341,12 +4396,12 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.11",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
-      "integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
+      "integrity": "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/levn": {
@@ -4367,7 +4422,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4400,7 +4455,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4421,7 +4475,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4442,7 +4495,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4463,7 +4515,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4484,7 +4535,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4505,7 +4555,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4526,7 +4575,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4547,7 +4595,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4568,7 +4615,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4589,7 +4635,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4610,7 +4655,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4698,7 +4742,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4708,7 +4752,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4718,7 +4762,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -4773,9 +4817,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "devOptional": true,
       "funding": [
         {
@@ -4792,9 +4836,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.1.0.tgz",
-      "integrity": "sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
       "funding": [
         {
           "type": "github",
@@ -4824,7 +4868,7 @@
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -4894,7 +4938,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -4948,9 +4992,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -4961,9 +5005,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "devOptional": true,
       "funding": [
         {
@@ -4981,7 +5025,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5049,7 +5093,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5199,21 +5243,21 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -5239,9 +5283,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -5361,7 +5405,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -5450,7 +5494,7 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -5463,14 +5507,14 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -5483,7 +5527,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -5604,9 +5648,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5702,20 +5746,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -5745,8 +5789,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -5787,7 +5831,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -5800,7 +5844,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -5811,7 +5855,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -5824,7 +5868,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5834,7 +5878,7 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -5888,10 +5932,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5913,7 +5957,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -5923,7 +5967,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/yallist": {
@@ -5947,9 +5991,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tauri-apps/plugin-opener": "^2.2",
     "@tauri-apps/plugin-store": "^2.2",
     "@tauri-apps/plugin-deep-link": "^2.2",
-    "better-auth": "^1.3",
+    "better-auth": "^1.6.17",
     "framer-motion": "^11.18",
     "i18next": "^24.2",
     "lucide-react": "^0.460",
@@ -67,7 +67,7 @@
     "tailwindcss": "^4.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.22",
-    "vite": "^7.0.4",
-    "vitest": "^3.0"
+    "vite": "^7.3.5",
+    "vitest": "^3.2.6"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3298,6 +3298,7 @@ dependencies = [
  "enigo",
  "futures-util",
  "http",
+ "libloading 0.8.9",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,9 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libloading = "0.8"
+
 [profile.release]
 codegen-units = 1
 opt-level = "s"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ pub mod audio;
 pub mod commands;
 pub mod error;
 pub mod hotkey;
+#[cfg(target_os = "linux")]
+mod linux_x11;
 pub mod llm;
 pub mod output;
 pub mod pipeline;
@@ -86,6 +88,9 @@ fn apply_linux_workarounds() {
 }
 
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    let xinitthreads_status = linux_x11::init_xlib_threads();
+
     apply_linux_workarounds();
 
     tracing_subscriber::fmt()
@@ -97,6 +102,19 @@ pub fn run() {
             ),
         )
         .init();
+
+    #[cfg(target_os = "linux")]
+    match xinitthreads_status {
+        linux_x11::XInitThreadsStatus::Enabled => {
+            tracing::debug!("Initialized Xlib thread support with XInitThreads");
+        }
+        linux_x11::XInitThreadsStatus::Unavailable => {
+            tracing::debug!("libX11 unavailable; skipping XInitThreads");
+        }
+        linux_x11::XInitThreadsStatus::Failed => {
+            tracing::warn!("XInitThreads returned failure; Xlib thread support may be unavailable");
+        }
+    }
 
     tauri::Builder::default()
         .plugin(tauri_plugin_sql::Builder::default().build())

--- a/src-tauri/src/linux_x11.rs
+++ b/src-tauri/src/linux_x11.rs
@@ -1,0 +1,70 @@
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum XInitThreadsStatus {
+    Enabled,
+    Unavailable,
+    Failed,
+}
+
+pub fn init_xlib_threads() -> XInitThreadsStatus {
+    init_xlib_threads_with(|| unsafe { xinitthreads_from_libx11() })
+}
+
+fn init_xlib_threads_with(
+    load: impl FnOnce() -> Result<unsafe extern "C" fn() -> i32, libloading::Error>,
+) -> XInitThreadsStatus {
+    let Ok(xinitthreads) = load() else {
+        return XInitThreadsStatus::Unavailable;
+    };
+
+    if unsafe { xinitthreads() } == 0 {
+        XInitThreadsStatus::Failed
+    } else {
+        XInitThreadsStatus::Enabled
+    }
+}
+
+unsafe fn xinitthreads_from_libx11() -> Result<unsafe extern "C" fn() -> i32, libloading::Error> {
+    // Keep libX11 loaded for the rest of the process after resolving XInitThreads.
+    let lib = Box::leak(Box::new(unsafe {
+        libloading::Library::new("libX11.so.6")?
+    }));
+    let symbol = unsafe { lib.get::<unsafe extern "C" fn() -> i32>(b"XInitThreads\0")? };
+    Ok(*symbol)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    unsafe extern "C" fn xinitthreads_success() -> i32 {
+        1
+    }
+
+    unsafe extern "C" fn xinitthreads_failure() -> i32 {
+        0
+    }
+
+    #[test]
+    fn reports_enabled_when_xinitthreads_succeeds() {
+        let status = init_xlib_threads_with(|| Ok(xinitthreads_success));
+
+        assert_eq!(status, XInitThreadsStatus::Enabled);
+    }
+
+    #[test]
+    fn reports_failed_when_xinitthreads_returns_zero() {
+        let status = init_xlib_threads_with(|| Ok(xinitthreads_failure));
+
+        assert_eq!(status, XInitThreadsStatus::Failed);
+    }
+
+    #[test]
+    fn reports_unavailable_when_libx11_cannot_be_loaded() {
+        let status = init_xlib_threads_with(|| {
+            unsafe { libloading::Library::new("__opentypeless_missing_lib__.so") }
+                .map(|_| xinitthreads_success as unsafe extern "C" fn() -> i32)
+        });
+
+        assert_eq!(status, XInitThreadsStatus::Unavailable);
+    }
+}

--- a/src-tauri/src/output/keyboard.rs
+++ b/src-tauri/src/output/keyboard.rs
@@ -9,6 +9,12 @@ use super::{OutputMode, TextOutput};
 const TYPE_CHUNK_SIZE: usize = 200;
 /// Delay between typing chunks.
 const TYPE_CHUNK_DELAY_MS: u64 = 5;
+/// Base timeout for macOS main-thread keyboard output.
+#[cfg(target_os = "macos")]
+const MACOS_TYPE_BASE_TIMEOUT_SECS: u64 = 30;
+/// Maximum timeout for macOS main-thread keyboard output.
+#[cfg(target_os = "macos")]
+const MACOS_TYPE_MAX_TIMEOUT_SECS: u64 = 300;
 
 /// Check if keyboard simulation is reliable on this platform.
 /// Returns Ok(()) if fine, or Err with a reason string for the caller.
@@ -33,59 +39,122 @@ pub fn check_keyboard_available() -> std::result::Result<(), String> {
     Ok(())
 }
 
-pub struct KeyboardOutput;
-
-impl Default for KeyboardOutput {
-    fn default() -> Self {
-        Self::new()
-    }
+pub struct KeyboardOutput {
+    #[cfg(target_os = "macos")]
+    app_handle: tauri::AppHandle,
 }
 
 impl KeyboardOutput {
-    pub fn new() -> Self {
-        Self
+    pub fn new(app_handle: &tauri::AppHandle) -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self {
+                app_handle: app_handle.clone(),
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = app_handle;
+            Self {}
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    async fn type_text_on_main_thread(&self, text: &str) -> Result<(), AppError> {
+        let text = text.to_string();
+        let timeout = macos_type_timeout(&text);
+        let app_handle = self.app_handle.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        app_handle
+            .run_on_main_thread(move || {
+                let result = type_text_sync(&text);
+                let _ = tx.send(result);
+            })
+            .map_err(|e| {
+                AppError::Output(format!(
+                    "Failed to schedule keyboard output on main thread: {}",
+                    e
+                ))
+            })?;
+
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(AppError::Output(
+                "Main thread keyboard output task was dropped".to_string(),
+            )),
+            Err(_) => Err(AppError::Output(format!(
+                "Main thread keyboard output timed out after {:.0}s",
+                timeout.as_secs_f64()
+            ))),
+        }
     }
 }
 
 #[async_trait]
 impl TextOutput for KeyboardOutput {
     async fn type_text(&self, text: &str) -> Result<(), AppError> {
-        let text = text.to_string();
-        tokio::task::spawn_blocking(move || -> Result<(), AppError> {
-            let mut enigo = Enigo::new(&Settings::default())
-                .map_err(|e| AppError::Output(format!("Failed to create Enigo: {:?}", e)))?;
+        #[cfg(target_os = "macos")]
+        {
+            return self.type_text_on_main_thread(text).await;
+        }
 
-            let lines: Vec<&str> = text.split('\n').collect();
-            for (i, line) in lines.iter().enumerate() {
-                if !line.is_empty() {
-                    for chunk in line.chars().collect::<Vec<_>>().chunks(TYPE_CHUNK_SIZE) {
-                        let s: String = chunk.iter().collect();
-                        enigo.text(&s).map_err(|e| {
-                            AppError::Output(format!("Failed to type text: {:?}", e))
-                        })?;
-                        std::thread::sleep(std::time::Duration::from_millis(TYPE_CHUNK_DELAY_MS));
-                    }
-                }
-                if i < lines.len() - 1 {
-                    enigo
-                        .key(Key::Shift, Direction::Press)
-                        .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
-                    enigo
-                        .key(Key::Return, Direction::Click)
-                        .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
-                    enigo
-                        .key(Key::Shift, Direction::Release)
-                        .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
-                }
-            }
-
-            Ok(())
-        })
-        .await
-        .map_err(|e| AppError::Output(format!("Spawn blocking error: {}", e)))?
+        #[cfg(not(target_os = "macos"))]
+        {
+            let text = text.to_string();
+            tokio::task::spawn_blocking(move || type_text_sync(&text))
+                .await
+                .map_err(|e| AppError::Output(format!("Spawn blocking error: {}", e)))?
+        }
     }
 
     fn mode(&self) -> OutputMode {
         OutputMode::Keyboard
     }
+}
+
+fn type_text_sync(text: &str) -> Result<(), AppError> {
+    let mut enigo = Enigo::new(&Settings::default())
+        .map_err(|e| AppError::Output(format!("Failed to create Enigo: {:?}", e)))?;
+
+    let lines: Vec<&str> = text.split('\n').collect();
+    for (i, line) in lines.iter().enumerate() {
+        if !line.is_empty() {
+            for chunk in line.chars().collect::<Vec<_>>().chunks(TYPE_CHUNK_SIZE) {
+                let s: String = chunk.iter().collect();
+                enigo
+                    .text(&s)
+                    .map_err(|e| AppError::Output(format!("Failed to type text: {:?}", e)))?;
+                std::thread::sleep(std::time::Duration::from_millis(TYPE_CHUNK_DELAY_MS));
+            }
+        }
+        if i < lines.len() - 1 {
+            enigo
+                .key(Key::Shift, Direction::Press)
+                .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
+            enigo
+                .key(Key::Return, Direction::Click)
+                .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
+            enigo
+                .key(Key::Shift, Direction::Release)
+                .map_err(|e| AppError::Output(format!("Key error: {:?}", e)))?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn macos_type_timeout(text: &str) -> std::time::Duration {
+    let char_count = text.chars().count();
+    let chunk_count = if char_count == 0 {
+        0
+    } else {
+        ((char_count - 1) / TYPE_CHUNK_SIZE) + 1
+    };
+    let seconds =
+        (MACOS_TYPE_BASE_TIMEOUT_SECS + chunk_count as u64).min(MACOS_TYPE_MAX_TIMEOUT_SECS);
+
+    std::time::Duration::from_secs(seconds)
 }

--- a/src-tauri/src/output/mod.rs
+++ b/src-tauri/src/output/mod.rs
@@ -16,9 +16,9 @@ pub trait TextOutput: Send + Sync {
     fn mode(&self) -> OutputMode;
 }
 
-pub fn create_output(mode: OutputMode) -> Box<dyn TextOutput> {
+pub fn create_output(mode: OutputMode, app_handle: &tauri::AppHandle) -> Box<dyn TextOutput> {
     match mode {
-        OutputMode::Keyboard => Box::new(keyboard::KeyboardOutput::new()),
+        OutputMode::Keyboard => Box::new(keyboard::KeyboardOutput::new(app_handle)),
         OutputMode::Clipboard => Box::new(clipboard::ClipboardOutput::new()),
     }
 }
@@ -28,11 +28,12 @@ pub fn create_output(mode: OutputMode) -> Box<dyn TextOutput> {
 /// Returns Ok(None) if primary output succeeded.
 /// Returns Err if both keyboard and clipboard failed.
 pub async fn output_with_fallback(
+    app_handle: &tauri::AppHandle,
     text: &str,
     mode: OutputMode,
 ) -> Result<Option<UserError>, String> {
     if mode == OutputMode::Clipboard {
-        let output = create_output(OutputMode::Clipboard);
+        let output = create_output(OutputMode::Clipboard, app_handle);
         return output
             .type_text(text)
             .await
@@ -41,7 +42,7 @@ pub async fn output_with_fallback(
     }
 
     // Try keyboard first
-    let keyboard = create_output(OutputMode::Keyboard);
+    let keyboard = create_output(OutputMode::Keyboard, app_handle);
     match keyboard.type_text(text).await {
         Ok(()) => Ok(None),
         Err(kb_err) => {
@@ -49,7 +50,7 @@ pub async fn output_with_fallback(
                 "Keyboard output failed: {}, falling back to clipboard",
                 kb_err
             );
-            let clipboard = create_output(OutputMode::Clipboard);
+            let clipboard = create_output(OutputMode::Clipboard, app_handle);
             match clipboard.type_text(text).await {
                 Ok(()) => Ok(Some(UserError {
                     code: "output_fallback_clipboard".to_string(),

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+#[cfg(not(target_os = "macos"))]
 use enigo::{Direction, Enigo, Key, Keyboard, Settings as EnigoSettings};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
@@ -35,64 +36,23 @@ pub fn is_accessibility_trusted() -> bool {
     }
 }
 
-/// On macOS, request Accessibility permission by showing the system authorization dialog.
-/// Uses AXIsProcessTrustedWithOptions with kAXTrustedCheckOptionPrompt = true.
+/// On macOS, request Accessibility permission by opening the system Privacy pane.
 /// Returns true if permission is already granted or on non-macOS platforms.
 pub fn request_accessibility_permission() -> bool {
     #[cfg(target_os = "macos")]
     {
-        #[link(name = "ApplicationServices", kind = "framework")]
-        extern "C" {
-            fn AXIsProcessTrustedWithOptions(options: *mut std::ffi::c_void) -> u8;
+        if is_accessibility_trusted() {
+            return true;
         }
-        #[link(name = "CoreFoundation", kind = "framework")]
-        extern "C" {
-            fn CFDictionaryCreate(
-                allocator: *mut std::ffi::c_void,
-                keys: *const *mut std::ffi::c_void,
-                values: *const *mut std::ffi::c_void,
-                num_values: isize,
-                key_callbacks: *const std::ffi::c_void,
-                value_callbacks: *const std::ffi::c_void,
-            ) -> *mut std::ffi::c_void;
-            fn CFStringCreateWithCString(
-                allocator: *mut std::ffi::c_void,
-                c_str: *const i8,
-                encoding: u32,
-            ) -> *mut std::ffi::c_void;
-            static kCFTypeDictionaryKeyCallBacks: std::ffi::c_void;
-            static kCFTypeDictionaryValueCallBacks: std::ffi::c_void;
-        }
-        // kCFBooleanTrue — we link CoreFoundation and use the known address pattern
-        #[link(name = "CoreFoundation", kind = "framework")]
-        extern "C" {
-            static kCFBooleanTrue: *mut std::ffi::c_void;
-        }
-        // kCFStringEncodingUTF8 = 0x08000100
-        const K_CF_STRING_ENCODING_UTF8: u32 = 0x08000100;
 
-        #[allow(clippy::manual_c_str_literals)]
-        unsafe {
-            let key = CFStringCreateWithCString(
-                std::ptr::null_mut(),
-                b"kAXTrustedCheckOptionPrompt\0".as_ptr() as *const i8,
-                K_CF_STRING_ENCODING_UTF8,
-            );
-            let value = kCFBooleanTrue;
-
-            let options = CFDictionaryCreate(
-                std::ptr::null_mut(),
-                &[key] as *const *mut std::ffi::c_void,
-                &[value] as *const *mut std::ffi::c_void,
-                1,
-                &kCFTypeDictionaryKeyCallBacks as *const std::ffi::c_void,
-                &kCFTypeDictionaryValueCallBacks as *const std::ffi::c_void,
-            );
-
-            let trusted = AXIsProcessTrustedWithOptions(options);
-            // options is leaked (trivial — called at most a few times)
-            trusted != 0
+        if let Err(e) = std::process::Command::new("/usr/bin/open")
+            .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+            .spawn()
+        {
+            tracing::warn!("Failed to open macOS Accessibility settings: {}", e);
         }
+
+        false
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -208,6 +168,44 @@ fn clipboard_copy_sentinel() -> String {
         std::process::id(),
         nanos
     )
+}
+
+#[cfg(target_os = "macos")]
+fn copy_selected_text_to_clipboard() -> bool {
+    match std::process::Command::new("/usr/bin/osascript")
+        .args([
+            "-e",
+            r#"tell application "System Events" to keystroke "c" using command down"#,
+        ])
+        .status()
+    {
+        Ok(status) if status.success() => true,
+        Ok(status) => {
+            tracing::warn!(
+                "macOS selected-text copy failed with exit code: {:?}",
+                status.code()
+            );
+            false
+        }
+        Err(e) => {
+            tracing::warn!("Failed to run osascript for selected-text copy: {}", e);
+            false
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn copy_selected_text_to_clipboard() -> bool {
+    let Ok(mut enigo) = Enigo::new(&EnigoSettings::default()) else {
+        return false;
+    };
+
+    let pressed = enigo.key(Key::Control, Direction::Press).is_ok();
+    if pressed {
+        let _ = enigo.key(Key::Unicode('c'), Direction::Click);
+        let _ = enigo.key(Key::Control, Direction::Release);
+    }
+    pressed
 }
 
 pub struct PipelineHandle {
@@ -337,17 +335,8 @@ impl PipelineHandle {
         let sentinel = clipboard_copy_sentinel();
         let _ = clipboard.set_text(&sentinel);
 
-        if let Ok(mut enigo) = Enigo::new(&EnigoSettings::default()) {
-            #[cfg(target_os = "macos")]
-            let modifier = Key::Meta;
-            #[cfg(not(target_os = "macos"))]
-            let modifier = Key::Control;
-
-            let pressed = enigo.key(modifier, Direction::Press).is_ok();
-            if pressed {
-                let _ = enigo.key(Key::Unicode('c'), Direction::Click);
-                let _ = enigo.key(modifier, Direction::Release);
-            }
+        if !copy_selected_text_to_clipboard() {
+            tracing::debug!("Selected text copy shortcut could not be sent");
         }
 
         std::thread::sleep(std::time::Duration::from_millis(CLIPBOARD_COPY_SETTLE_MS));
@@ -1266,7 +1255,7 @@ impl PipelineHandle {
             mode
         };
 
-        match output::output_with_fallback(text, effective_mode).await {
+        match output::output_with_fallback(&self.app_handle, text, effective_mode).await {
             Ok(Some(user_error)) => {
                 tracing::info!("Output fell back to clipboard");
                 let _ = self.app_handle.emit("pipeline:warning", &user_error);


### PR DESCRIPTION
## Summary

- Add early Linux `XInitThreads` initialization to address Ubuntu/X11 startup crashes.
- Replace the macOS Accessibility prompt FFI path with opening the System Settings Accessibility pane.
- Use macOS-only `osascript` for selected-text Cmd+C while preserving Windows/Linux Enigo behavior.
- Route macOS keyboard output through Tauri `run_on_main_thread` with acknowledgement and timeout.
- Update Vite/Vitest/better-auth dependency ranges and lockfile to clear high/critical npm audit findings.
- Add a detailed platform release stabilization spec.

## Validation

- `npm ci`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing 3 warnings)
- `npm run format:check`
- `npx prettier --check docs/2026-06-13-platform-release-stabilization-spec.md`
- `npm test` (117 tests)
- `npm run build`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml` (110 tests)
- `git diff --check`
- `npm run tauri -- build` on local macOS aarch64

## Manual follow-up before release

- Verify #48 on Ubuntu 22.04 MATE/X11.
- Verify macOS Accessibility, selected text, Chinese IME, keyboard output, and clipboard fallback.
- Run or replace the full release matrix once Actions/billing is available.