### PR TITLE
feat: add Requesty as an OpenAI-compatible LLM provider

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Locale)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Locale)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (ローカル)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (ローカル)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (로컬)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (로컬)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Local)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Локальный)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (Локальный)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless Cloud"
     }
   }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -428,6 +428,7 @@
       "claude": "Claude",
       "ollama": "Ollama (本地)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless 云服务"
     }
   }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -887,6 +887,7 @@
       "claude": "Claude",
       "ollama": "Ollama (本地)",
       "openrouter": "OpenRouter",
+      "requesty": "Requesty",
       "cloud": "OpenTypeless 云服务"
     }
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -94,6 +94,7 @@ export const LLM_PROVIDERS: { value: string; labelKey: string }[] = [
   { value: 'claude', labelKey: 'providers.llm.claude' },
   { value: 'ollama', labelKey: 'providers.llm.ollama' },
   { value: 'openrouter', labelKey: 'providers.llm.openrouter' },
+  { value: 'requesty', labelKey: 'providers.llm.requesty' },
   { value: 'cloud', labelKey: 'providers.llm.cloud' },
 ] as const
 
@@ -112,6 +113,7 @@ export const LLM_DEFAULT_CONFIG: Record<string, { baseUrl: string; model: string
   claude: { baseUrl: 'https://openrouter.ai/api/v1', model: 'anthropic/claude-sonnet-4' },
   ollama: { baseUrl: 'http://localhost:11434/v1', model: 'llama3.2' },
   openrouter: { baseUrl: 'https://openrouter.ai/api/v1', model: 'openai/gpt-4o-mini' },
+  requesty: { baseUrl: 'https://router.requesty.ai/v1', model: 'openai/gpt-4o-mini' },
   cloud: { baseUrl: `${API_BASE_URL}/api/proxy`, model: 'default' },
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -152,6 +152,7 @@ export const LLM_PROVIDERS: { value: string; labelKey: string }[] = [
   { value: 'claude', labelKey: 'providers.llm.claude' },
   { value: 'ollama', labelKey: 'providers.llm.ollama' },
   { value: 'openrouter', labelKey: 'providers.llm.openrouter' },
+  { value: 'requesty', labelKey: 'providers.llm.requesty' },
   { value: 'cloud', labelKey: 'providers.llm.cloud' },
 ] as const
 
@@ -178,6 +179,7 @@ export const LLM_DEFAULT_CONFIG: Record<string, { baseUrl: string; model: string
   claude: { baseUrl: 'https://api.anthropic.com/v1', model: 'claude-sonnet-4-0' },
   ollama: { baseUrl: 'http://localhost:11434/v1', model: 'llama3.2' },
   openrouter: { baseUrl: 'https://openrouter.ai/api/v1', model: 'openai/gpt-4o-mini' },
+  requesty: { baseUrl: 'https://router.requesty.ai/v1', model: 'openai/gpt-4o-mini' },
   cloud: { baseUrl: `${API_BASE_URL}/api/proxy`, model: 'default' },
 }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -23,6 +23,7 @@ export type LlmProvider =
   | 'claude'
   | 'ollama'
   | 'openrouter'
+  | 'requesty'
   | 'cloud'
 export type OutputMode = 'keyboard' | 'clipboard'
 export type HotkeyMode = 'hold' | 'toggle'

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -40,6 +40,7 @@ export type LlmProvider =
   | 'claude'
   | 'ollama'
   | 'openrouter'
+  | 'requesty'
   | 'cloud'
 export type OutputMode = 'keyboard' | 'clipboard'
 export type PasteShortcut = 'ctrlV' | 'ctrlShiftV' | 'shiftInsert'


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible LLM provider

This PR adds [Requesty](https://requesty.ai) as a native LLM provider, mirroring the existing OpenRouter integration as closely as possible.

Requesty is an OpenAI-compatible LLM gateway:
- Base URL: `https://router.requesty.ai/v1`
- Auth: standard `Authorization: Bearer` API key (`REQUESTY_API_KEY`)
- Model naming: `provider/model` (e.g. `openai/gpt-4o-mini`)

Because it is OpenAI-compatible and the app already forwards `llm_base_url` generically, wiring it in only required registering the new provider id alongside the others.

### Wiring sites
- `src/stores/appStore.ts`: added `'requesty'` to the `LlmProvider` string-literal union. The default provider selection is unchanged.
- `src/lib/constants.ts`: added a `requesty` entry to `LLM_PROVIDERS` (label key `providers.llm.requesty`) and to `LLM_DEFAULT_CONFIG` (`baseUrl: 'https://router.requesty.ai/v1'`, `model: 'openai/gpt-4o-mini'`), mirroring the openrouter entry. API-key handling is identical to the other OpenAI-compatible providers.
- `src/i18n/locales/*.json`: added `providers.llm.requesty = "Requesty"` to all 10 locale files (en, de, es, fr, it, ja, ko, pt, ru, zh).

No Rust changes were needed: the backend (`src-tauri/`) stores `llm_provider`/`llm_base_url` as generic strings and forwards the configured base URL, there is no per-provider enum to extend.

### Verification
- `npx tsc --noEmit`: passes
- `npx eslint src/lib/constants.ts src/stores/appStore.ts`: clean
- `npx prettier --check` on changed files: clean
- `npx vitest run`: 125 tests pass (14 files), including the Settings and LlmPane suites
- Live chat completion against `https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` returned HTTP 200 and a valid completion.

Docs: https://requesty.ai , https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

