### PR TITLE
feat(meeting): transcribe + persist + export meeting transcripts (MEL-76)

### DIFF
--- a/src-tauri/src/commands/meeting.rs
+++ b/src-tauri/src/commands/meeting.rs
@@ -1,0 +1,85 @@
+//! Tauri command surface for reading and exporting meeting transcripts
+//! (MEL-76). These signatures are the unlock point for the frontend (MEL-77):
+//! list past meetings, read one in full, export one to a file.
+
+use tauri::Manager;
+
+use crate::storage::meeting::{self, MeetingDbStore, MeetingDetail, MeetingSession};
+
+/// List past meetings, newest first (headers only, no segment text).
+#[tauri::command]
+pub async fn list_meetings(
+    store: tauri::State<'_, MeetingDbStore>,
+    limit: u32,
+    offset: u32,
+) -> Result<Vec<MeetingSession>, String> {
+    store
+        .list_sessions(limit, offset)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Read one meeting in full: header + ordered segments + merged transcript.
+/// Returns `null` if the id does not exist.
+#[tauri::command]
+pub async fn get_meeting(
+    store: tauri::State<'_, MeetingDbStore>,
+    session_id: i64,
+) -> Result<Option<MeetingDetail>, String> {
+    store.get_session(session_id).await.map_err(|e| e.to_string())
+}
+
+/// Delete one meeting and its segments.
+#[tauri::command]
+pub async fn delete_meeting(
+    store: tauri::State<'_, MeetingDbStore>,
+    session_id: i64,
+) -> Result<(), String> {
+    store
+        .delete_session(session_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Export a whole meeting transcript to a file in the user's Downloads folder
+/// (MEL-74 default). `format` is "md" (default) or "txt". Returns the written
+/// file path so the frontend can reveal it.
+#[tauri::command]
+pub async fn export_meeting(
+    app: tauri::AppHandle,
+    store: tauri::State<'_, MeetingDbStore>,
+    session_id: i64,
+    format: Option<String>,
+) -> Result<String, String> {
+    let detail = store
+        .get_session(session_id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Meeting {session_id} not found"))?;
+
+    let fmt = format.as_deref().unwrap_or("md");
+    let (body, ext) = match fmt {
+        "txt" => (meeting::render_plain_text(&detail), "txt"),
+        "md" | "markdown" => (meeting::render_markdown(&detail), "md"),
+        other => return Err(format!("Unsupported export format: {other}")),
+    };
+
+    let dir = app
+        .path()
+        .download_dir()
+        .map_err(|e| format!("Cannot resolve Downloads folder: {e}"))?;
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+
+    // Stable, recognizable filename: meeting-<id>-<created-date>.<ext>.
+    let date_slug = detail
+        .session
+        .created_at
+        .chars()
+        .map(|c| if c == ':' { '-' } else { c })
+        .collect::<String>();
+    let filename = format!("meeting-{}-{}.{}", detail.session.id, date_slug, ext);
+    let path = dir.join(filename);
+
+    std::fs::write(&path, body).map_err(|e| e.to_string())?;
+    Ok(path.to_string_lossy().to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod config;
 pub mod dictionary;
 pub mod history;
 pub mod llm;
+pub mod meeting;
 pub mod misc;
 pub mod stt;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,8 +182,10 @@ pub fn run() {
             let config_manager = storage::ConfigManager::new(app_handle.clone());
             let history_store = storage::HistoryStore::new(db_path.clone())
                 .map_err(|e| anyhow::anyhow!("Failed to init history store: {}", e))?;
-            let dictionary_store = storage::DictionaryStore::new(db_path)
+            let dictionary_store = storage::DictionaryStore::new(db_path.clone())
                 .map_err(|e| anyhow::anyhow!("Failed to init dictionary store: {}", e))?;
+            let meeting_store = storage::meeting::MeetingDbStore::new(db_path)
+                .map_err(|e| anyhow::anyhow!("Failed to init meeting store: {}", e))?;
 
             let shared_client = reqwest::Client::builder()
                 .pool_max_idle_per_host(2)
@@ -206,6 +208,7 @@ pub fn run() {
             app.manage(config_manager);
             app.manage(history_store);
             app.manage(dictionary_store);
+            app.manage(meeting_store);
             app.manage(shared_client);
             app.manage(pipeline_handle);
             app.manage(meeting_handle);
@@ -467,6 +470,10 @@ pub fn run() {
             commands::llm::fetch_llm_models,
             commands::history::get_history,
             commands::history::clear_history,
+            commands::meeting::list_meetings,
+            commands::meeting::get_meeting,
+            commands::meeting::delete_meeting,
+            commands::meeting::export_meeting,
             commands::dictionary::get_dictionary,
             commands::dictionary::add_dictionary_entry,
             commands::dictionary::remove_dictionary_entry,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod hotkey;
 #[cfg(target_os = "linux")]
 mod linux_x11;
 pub mod llm;
+pub mod meeting;
 pub mod output;
 pub mod pipeline;
 pub mod storage;
@@ -66,6 +67,30 @@ async fn stop_recording(state: tauri::State<'_, pipeline::PipelineHandle>) -> Re
 fn abort_recording(state: tauri::State<'_, pipeline::PipelineHandle>) -> Result<(), String> {
     state.abort();
     Ok(())
+}
+
+#[tauri::command]
+async fn start_meeting(
+    state: tauri::State<'_, meeting::MeetingHandle>,
+    config: tauri::State<'_, storage::ConfigManager>,
+) -> Result<(), String> {
+    let cfg = config.load().await.unwrap_or_default();
+    let language = if cfg.stt_language == "multi" {
+        None
+    } else {
+        Some(cfg.stt_language.clone())
+    };
+    state.start(cfg.stt_provider.clone(), language).await
+}
+
+#[tauri::command]
+async fn stop_meeting(state: tauri::State<'_, meeting::MeetingHandle>) -> Result<(), String> {
+    state.stop().await
+}
+
+#[tauri::command]
+fn is_meeting_active(state: tauri::State<'_, meeting::MeetingHandle>) -> bool {
+    state.is_active()
 }
 
 /// On Linux with NVIDIA proprietary drivers + Wayland, WebKit's DMA-BUF renderer
@@ -170,6 +195,8 @@ pub fn run() {
             let pipeline_handle =
                 pipeline::PipelineHandle::new(app_handle.clone(), shared_client.clone());
 
+            let meeting_handle = meeting::MeetingHandle::new(app_handle.clone());
+
             // Load initial config to get hotkey
             let initial_config =
                 tauri::async_runtime::block_on(config_manager.load()).unwrap_or_default();
@@ -181,6 +208,7 @@ pub fn run() {
             app.manage(dictionary_store);
             app.manage(shared_client);
             app.manage(pipeline_handle);
+            app.manage(meeting_handle);
             app.manage(HotkeyModeCache(Arc::new(Mutex::new(
                 initial_config.hotkey_mode.clone(),
             ))));
@@ -425,6 +453,9 @@ pub fn run() {
             start_recording,
             stop_recording,
             abort_recording,
+            start_meeting,
+            stop_meeting,
+            is_meeting_active,
             commands::misc::check_accessibility_permission,
             commands::misc::request_accessibility_permission,
             commands::config::get_config,

--- a/src-tauri/src/meeting/adapters.rs
+++ b/src-tauri/src/meeting/adapters.rs
@@ -1,14 +1,20 @@
 //! Desktop (Tauri / cpal) implementations of the `meeting::engine` trait
 //! boundaries. These are the host-specific glue; the engine itself stays
-//! UI-agnostic. The `Transcriber` and `MeetingStore` adapters that wrap the
-//! real `SttProvider` and SQLite are intentionally **out of scope for MEL-75**
-//! and land in MEL-76 — this task ships only the audio + events adapters plus
-//! the engine's in-memory stubs (`engine::stub`).
+//! UI-agnostic.
+//!
+//! MEL-75 shipped the audio + events adapters. MEL-76 adds [`SttTranscriber`],
+//! the real `Transcriber` that wraps the existing `SttProvider` family
+//! (glm-asr / cloud / whisper-compat / deepgram / …) to turn one segment's PCM
+//! into text. The SQLite `MeetingStore` impl lives in
+//! `crate::storage::meeting::MeetingDbStore`.
 
+use async_trait::async_trait;
 use tauri::Emitter;
 use tokio::sync::mpsc;
 
-use super::engine::{MeetingEvent, MeetingEvents, PcmChunk, SegStatus};
+use super::engine::{MeetingEvent, MeetingEvents, PcmChunk, SegStatus, Transcriber};
+use crate::stt::{self, SttConfig, TranscriptEvent};
+use crate::stt::whisper_compat::WhisperCompatConfig;
 
 /// Adapts the existing cpal capture channel (`AudioCaptureHandle` →
 /// `mpsc::Receiver<Vec<u8>>`) to the engine's non-blocking `AudioSource`.
@@ -88,6 +94,106 @@ impl MeetingEvents for TauriMeetingEvents {
     }
 }
 
+/// Real transcriber: wraps the existing `SttProvider` family. Each segment is
+/// transcribed as an independent one-shot (connect → send whole segment →
+/// drain), mirroring the instant-pipeline lifecycle but for a closed buffer.
+///
+/// `is_streaming()` distinguishes realtime websocket providers (deepgram /
+/// assemblyai — transcribe each segment the moment it is cut, design §3B) from
+/// file-upload providers (glm-asr / cloud / whisper — text comes back from
+/// `disconnect()`, deferred to finalize, design §3A).
+pub struct SttTranscriber {
+    provider_name: String,
+    config: SttConfig,
+    custom_whisper_config: Option<WhisperCompatConfig>,
+    client: reqwest::Client,
+}
+
+impl SttTranscriber {
+    pub fn new(
+        provider_name: String,
+        config: SttConfig,
+        custom_whisper_config: Option<WhisperCompatConfig>,
+        client: reqwest::Client,
+    ) -> Self {
+        Self {
+            provider_name,
+            config,
+            custom_whisper_config,
+            client,
+        }
+    }
+
+    /// Streaming providers expose a realtime websocket and yield transcripts
+    /// via `recv_transcript`; everything else uploads a finished buffer.
+    fn provider_is_streaming(name: &str) -> bool {
+        matches!(name, "deepgram" | "assemblyai")
+    }
+}
+
+#[async_trait]
+impl Transcriber for SttTranscriber {
+    async fn transcribe_segment(&self, pcm: &[u8], _sample_rate: u32) -> Result<String, String> {
+        let mut provider = stt::create_provider(
+            &self.provider_name,
+            self.custom_whisper_config.clone(),
+            Some(self.client.clone()),
+        )
+        .map_err(|e| e.to_string())?;
+
+        provider
+            .connect(&self.config)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Feed the whole segment. cpal capture and the engine both run 16 kHz
+        // mono 16-bit, so the bytes go straight through.
+        provider
+            .send_audio(pcm)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if Self::provider_is_streaming(&self.provider_name) {
+            // Streaming provider: drain final transcripts, then close. The
+            // websocket has no EOF, so we poll until the buffer is exhausted
+            // or it reports an error.
+            let mut text = String::new();
+            loop {
+                match provider.recv_transcript().await {
+                    Ok(Some(TranscriptEvent::Final { text: t, .. })) => {
+                        if !t.is_empty() {
+                            if !text.is_empty() {
+                                text.push(' ');
+                            }
+                            text.push_str(&t);
+                        }
+                    }
+                    Ok(Some(TranscriptEvent::Error { message })) => {
+                        let _ = provider.disconnect().await;
+                        return Err(message);
+                    }
+                    Ok(Some(_)) => continue, // Partial / speech markers: ignore.
+                    Ok(None) => break,       // Stream closed.
+                    Err(e) => {
+                        let _ = provider.disconnect().await;
+                        return Err(e.to_string());
+                    }
+                }
+            }
+            let _ = provider.disconnect().await;
+            Ok(text)
+        } else {
+            // File-upload provider: the transcript comes from disconnect().
+            let result = provider.disconnect().await.map_err(|e| e.to_string())?;
+            Ok(result.unwrap_or_default())
+        }
+    }
+
+    fn is_streaming(&self) -> bool {
+        Self::provider_is_streaming(&self.provider_name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -105,6 +211,17 @@ mod tests {
 
         // Channel now empty → None (non-blocking).
         assert!(src.try_recv().is_none());
+    }
+
+    #[test]
+    fn streaming_providers_are_classified_correctly() {
+        assert!(SttTranscriber::provider_is_streaming("deepgram"));
+        assert!(SttTranscriber::provider_is_streaming("assemblyai"));
+        // File-upload providers are not streaming.
+        assert!(!SttTranscriber::provider_is_streaming("glm-asr"));
+        assert!(!SttTranscriber::provider_is_streaming("cloud"));
+        assert!(!SttTranscriber::provider_is_streaming("custom-whisper"));
+        assert!(!SttTranscriber::provider_is_streaming("openai-whisper"));
     }
 
     #[test]

--- a/src-tauri/src/meeting/adapters.rs
+++ b/src-tauri/src/meeting/adapters.rs
@@ -1,0 +1,117 @@
+//! Desktop (Tauri / cpal) implementations of the `meeting::engine` trait
+//! boundaries. These are the host-specific glue; the engine itself stays
+//! UI-agnostic. The `Transcriber` and `MeetingStore` adapters that wrap the
+//! real `SttProvider` and SQLite are intentionally **out of scope for MEL-75**
+//! and land in MEL-76 — this task ships only the audio + events adapters plus
+//! the engine's in-memory stubs (`engine::stub`).
+
+use tauri::Emitter;
+use tokio::sync::mpsc;
+
+use super::engine::{MeetingEvent, MeetingEvents, PcmChunk, SegStatus};
+
+/// Adapts the existing cpal capture channel (`AudioCaptureHandle` →
+/// `mpsc::Receiver<Vec<u8>>`) to the engine's non-blocking `AudioSource`.
+///
+/// The meeting core reuses the *same* dedicated-thread capture pipeline as
+/// instant transcription (design §0.2): it only swaps the consumer end.
+pub struct ChannelAudioSource {
+    rx: mpsc::Receiver<Vec<u8>>,
+    sample_rate: u32,
+}
+
+impl ChannelAudioSource {
+    pub fn new(rx: mpsc::Receiver<Vec<u8>>, sample_rate: u32) -> Self {
+        Self { rx, sample_rate }
+    }
+}
+
+impl super::engine::AudioSource for ChannelAudioSource {
+    fn try_recv(&mut self) -> Option<PcmChunk> {
+        match self.rx.try_recv() {
+            Ok(bytes) => Some(PcmChunk {
+                bytes,
+                sample_rate: self.sample_rate,
+            }),
+            Err(_) => None, // Empty or Disconnected → nothing ready this tick.
+        }
+    }
+}
+
+/// Forwards engine events onto the Tauri event bus as `meeting:*` events,
+/// reusing the existing `app_handle.emit` pattern (design §1.4).
+pub struct TauriMeetingEvents {
+    app_handle: tauri::AppHandle,
+}
+
+impl TauriMeetingEvents {
+    pub fn new(app_handle: tauri::AppHandle) -> Self {
+        Self { app_handle }
+    }
+}
+
+fn seg_status_str(status: SegStatus) -> &'static str {
+    match status {
+        SegStatus::Pending => "pending",
+        SegStatus::Transcribing => "transcribing",
+        SegStatus::Done => "done",
+        SegStatus::Failed => "failed",
+    }
+}
+
+impl MeetingEvents for TauriMeetingEvents {
+    fn emit(&self, ev: MeetingEvent) {
+        match ev {
+            MeetingEvent::State(state) => {
+                let _ = self.app_handle.emit("meeting:state", state);
+            }
+            MeetingEvent::Segment { idx, status, text } => {
+                let _ = self.app_handle.emit(
+                    "meeting:segment",
+                    serde_json::json!({
+                        "index": idx,
+                        "status": seg_status_str(status),
+                        "text": text,
+                    }),
+                );
+            }
+            MeetingEvent::Progress { done, total } => {
+                let _ = self.app_handle.emit(
+                    "meeting:progress",
+                    serde_json::json!({ "done": done, "total": total }),
+                );
+            }
+            MeetingEvent::Error(message) => {
+                let _ = self.app_handle.emit("meeting:error", message);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meeting::engine::AudioSource;
+
+    #[test]
+    fn channel_source_yields_chunks_then_none() {
+        let (tx, rx) = mpsc::channel::<Vec<u8>>(4);
+        tx.try_send(vec![1, 2, 3, 4]).unwrap();
+        let mut src = ChannelAudioSource::new(rx, 16000);
+
+        let chunk = src.try_recv().expect("first chunk present");
+        assert_eq!(chunk.bytes, vec![1, 2, 3, 4]);
+        assert_eq!(chunk.sample_rate, 16000);
+
+        // Channel now empty → None (non-blocking).
+        assert!(src.try_recv().is_none());
+    }
+
+    #[test]
+    fn seg_status_strings_are_stable() {
+        assert_eq!(seg_status_str(SegStatus::Pending), "pending");
+        assert_eq!(seg_status_str(SegStatus::Transcribing), "transcribing");
+        assert_eq!(seg_status_str(SegStatus::Done), "done");
+        assert_eq!(seg_status_str(SegStatus::Failed), "failed");
+    }
+}

--- a/src-tauri/src/meeting/engine.rs
+++ b/src-tauri/src/meeting/engine.rs
@@ -1,0 +1,828 @@
+//! UI-agnostic meeting recording core.
+//!
+//! This module contains the portable `listen → segment` logic for the
+//! meeting / long-recording mode (MEL-74 design §5). It deliberately has
+//! **zero** dependencies on Tauri, rusqlite, or cpal so that it can be lifted
+//! into a standalone `meeting_core` crate (and reused by a future wearable
+//! host) without modification.
+//!
+//! The desktop host provides implementations of the traits below
+//! (`AudioSource`, `Transcriber`, `MeetingStore`, `MeetingEvents`) in
+//! `meeting::adapters`; this file owns only the state machine and the
+//! segment-timing arithmetic.
+
+use async_trait::async_trait;
+
+/// PCM sample format the engine assumes throughout: 16 kHz, mono, 16-bit LE.
+/// One sample = 2 bytes. Mirrors `audio::AudioConfig::default()`.
+pub const PCM_SAMPLE_RATE: u32 = 16000;
+pub const PCM_BYTES_PER_SAMPLE: usize = 2;
+
+/// A chunk of raw PCM bytes pulled from the audio source (non-blocking).
+#[derive(Debug, Clone)]
+pub struct PcmChunk {
+    pub bytes: Vec<u8>,
+    pub sample_rate: u32,
+}
+
+/// Lifecycle state of a meeting recording (MEL-74 design §1.3).
+///
+/// `Recording → Recording` segment cuts are intra-state events and do not
+/// change this value; only the four transitions below are observable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingState {
+    Idle,
+    Recording,
+    Finalizing,
+    Archived,
+}
+
+/// Per-segment transcription status, surfaced to the UI for the rolling list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SegStatus {
+    Pending,
+    Transcribing,
+    Done,
+    Failed,
+}
+
+/// Tunable timing knobs (MEL-74 design §2.1). Defaults are the locked-in
+/// product values: 5-min segments, 3-hr cap, 15-s minimum segment.
+#[derive(Debug, Clone, Copy)]
+pub struct MeetingConfig {
+    /// Cut a new segment after the current one reaches this length.
+    pub segment_interval_secs: u32,
+    /// Auto-finalize the whole meeting once total elapsed reaches this.
+    pub max_meeting_secs: u32,
+    /// Never emit a standalone segment shorter than this (merge into the next).
+    pub min_segment_secs: u32,
+}
+
+impl Default for MeetingConfig {
+    fn default() -> Self {
+        Self {
+            segment_interval_secs: 300,   // 5 minutes
+            max_meeting_secs: 10800,      // 3 hours
+            min_segment_secs: 15,
+        }
+    }
+}
+
+/// Metadata describing one finished segment handed to the downstream
+/// (transcribe + store) layer. This struct plus the raw PCM bytes is the
+/// MEL-75 → MEL-76 handoff contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentMeta {
+    /// 0-based segment index within the session.
+    pub seg_index: u32,
+    /// Offset of this segment's start relative to meeting start.
+    pub start_ms: u64,
+    /// Offset of this segment's end relative to meeting start.
+    pub end_ms: u64,
+}
+
+impl SegmentMeta {
+    pub fn duration_ms(&self) -> u64 {
+        self.end_ms.saturating_sub(self.start_ms)
+    }
+}
+
+/// A closed segment: metadata + the PCM bytes captured during it.
+/// This is what the engine produces and the `Transcriber` consumes.
+#[derive(Debug, Clone)]
+pub struct Segment {
+    pub meta: SegmentMeta,
+    pub pcm: Vec<u8>,
+}
+
+/// Events emitted by the engine for the host to forward to its UI / logs.
+#[derive(Debug, Clone)]
+pub enum MeetingEvent {
+    State(MeetingState),
+    Segment {
+        idx: u32,
+        status: SegStatus,
+        text: String,
+    },
+    Progress {
+        done: u32,
+        total: u32,
+    },
+    Error(String),
+}
+
+/// Session metadata recorded at meeting start.
+#[derive(Debug, Clone)]
+pub struct SessionMeta {
+    pub created_at: String,
+    pub stt_provider: String,
+    pub language: Option<String>,
+}
+
+/// One transcribed segment row to persist.
+#[derive(Debug, Clone)]
+pub struct SegmentRow {
+    pub seg_index: u32,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub status: SegStatus,
+    pub text: String,
+}
+
+// ─── Host-supplied trait boundaries (MEL-74 design §5.3) ───
+//
+// The engine depends only on these traits. The desktop host wires concrete
+// cpal / SttProvider / SQLite / Tauri implementations in `adapters.rs`; a
+// wearable host would supply different ones. `MeetingStore` and `Transcriber`
+// are *defined* here (MEL-75) but the real desktop implementations land in
+// MEL-76 — MEL-75 ships only in-memory stubs (see `stub` below).
+
+/// Pulls raw PCM from the capture backend without blocking.
+pub trait AudioSource: Send {
+    /// Return the next available PCM chunk, or `None` if none is ready yet.
+    fn try_recv(&mut self) -> Option<PcmChunk>;
+}
+
+/// Turns one segment's PCM into text. The desktop adapter wraps the existing
+/// `SttProvider` (connect → send whole segment → disconnect) behind this.
+#[async_trait]
+pub trait Transcriber: Send + Sync {
+    async fn transcribe_segment(&self, pcm: &[u8], sample_rate: u32) -> Result<String, String>;
+    /// Streaming providers transcribe each segment as soon as it is cut
+    /// (design §3B); file-based providers wait until finalize (design §3A).
+    fn is_streaming(&self) -> bool;
+}
+
+/// Persists session + segment rows. Defined here; SQLite impl is MEL-76.
+pub trait MeetingStore: Send + Sync {
+    fn create_session(&self, meta: SessionMeta) -> Result<i64, String>;
+    fn upsert_segment(&self, session_id: i64, seg: SegmentRow) -> Result<(), String>;
+    fn finalize_session(
+        &self,
+        session_id: i64,
+        full_text: &str,
+        duration_ms: u64,
+    ) -> Result<(), String>;
+}
+
+/// Emits engine events to the host (Tauri `emit`, a log, a BLE notify, …).
+pub trait MeetingEvents: Send + Sync {
+    fn emit(&self, ev: MeetingEvent);
+}
+
+// ─── Pure segmentation timing logic (the deterministic core) ───
+
+/// Bytes captured per second of audio at the engine's PCM format.
+pub fn bytes_per_sec(sample_rate: u32) -> u64 {
+    sample_rate as u64 * PCM_BYTES_PER_SAMPLE as u64
+}
+
+/// Convert a byte count of PCM into elapsed milliseconds.
+pub fn pcm_bytes_to_ms(bytes: u64, sample_rate: u32) -> u64 {
+    let bps = bytes_per_sec(sample_rate);
+    if bps == 0 {
+        return 0;
+    }
+    bytes * 1000 / bps
+}
+
+/// Decide whether the in-progress segment should be cut now.
+///
+/// A cut happens once the current segment has accumulated at least
+/// `segment_interval_secs` of audio. `min_segment_secs` guards the *opposite*
+/// direction (manual stop / finalize of a tiny tail) and is enforced by
+/// [`should_emit_on_finalize`], so a regular interval cut only checks the
+/// upper bound here.
+pub fn should_cut_segment(current_segment_ms: u64, config: &MeetingConfig) -> bool {
+    current_segment_ms >= config.segment_interval_secs as u64 * 1000
+}
+
+/// Decide whether the meeting has hit its hard duration cap and must finalize.
+pub fn should_auto_finalize(total_elapsed_ms: u64, config: &MeetingConfig) -> bool {
+    total_elapsed_ms >= config.max_meeting_secs as u64 * 1000
+}
+
+/// On manual stop / auto-finalize, decide whether the trailing buffer is long
+/// enough to become its own segment. A tail shorter than `min_segment_secs`
+/// is still emitted **if it is the only segment** (otherwise the meeting would
+/// have zero segments); when prior segments exist a sub-minimum tail is merged
+/// away by the caller (dropped here, its audio already flushed with the last
+/// cut is not — see engine: tail always emitted when it is segment 0).
+pub fn should_emit_on_finalize(
+    tail_ms: u64,
+    prior_segment_count: u32,
+    config: &MeetingConfig,
+) -> bool {
+    if prior_segment_count == 0 {
+        // First and only segment: always emit, even if short.
+        return tail_ms > 0;
+    }
+    tail_ms >= config.min_segment_secs as u64 * 1000
+}
+
+// ─── In-memory stub implementations (MEL-75 self-test scaffolding) ───
+//
+// Per MEL-74 design §6, MEL-75 defines the trait boundaries and ships
+// **stub** implementations so the engine can be exercised end-to-end before
+// the real SQLite store (MEL-76) and SttProvider adapter (MEL-76) exist.
+// These also back the unit tests below.
+pub mod stub {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Feeds a fixed queue of PCM chunks, then returns `None`.
+    pub struct VecAudioSource {
+        chunks: std::collections::VecDeque<PcmChunk>,
+    }
+
+    impl VecAudioSource {
+        pub fn new(chunks: Vec<PcmChunk>) -> Self {
+            Self {
+                chunks: chunks.into(),
+            }
+        }
+    }
+
+    impl AudioSource for VecAudioSource {
+        fn try_recv(&mut self) -> Option<PcmChunk> {
+            self.chunks.pop_front()
+        }
+    }
+
+    /// Echoes a deterministic transcript per segment; records every call.
+    pub struct StubTranscriber {
+        pub streaming: bool,
+        pub calls: Mutex<Vec<(usize, u32)>>,
+    }
+
+    impl StubTranscriber {
+        pub fn new(streaming: bool) -> Self {
+            Self {
+                streaming,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Transcriber for StubTranscriber {
+        async fn transcribe_segment(
+            &self,
+            pcm: &[u8],
+            sample_rate: u32,
+        ) -> Result<String, String> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((pcm.len(), sample_rate));
+            Ok(format!("[seg {} bytes]", pcm.len()))
+        }
+
+        fn is_streaming(&self) -> bool {
+            self.streaming
+        }
+    }
+
+    /// Records sessions / segments in memory for assertions.
+    #[derive(Default)]
+    pub struct StubStore {
+        pub sessions: Mutex<Vec<SessionMeta>>,
+        pub segments: Mutex<Vec<(i64, SegmentRow)>>,
+        pub finalized: Mutex<Vec<(i64, String, u64)>>,
+    }
+
+    impl MeetingStore for StubStore {
+        fn create_session(&self, meta: SessionMeta) -> Result<i64, String> {
+            let mut s = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+            s.push(meta);
+            Ok(s.len() as i64)
+        }
+
+        fn upsert_segment(&self, session_id: i64, seg: SegmentRow) -> Result<(), String> {
+            self.segments
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((session_id, seg));
+            Ok(())
+        }
+
+        fn finalize_session(
+            &self,
+            session_id: i64,
+            full_text: &str,
+            duration_ms: u64,
+        ) -> Result<(), String> {
+            self.finalized
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((session_id, full_text.to_string(), duration_ms));
+            Ok(())
+        }
+    }
+
+    /// Collects emitted events for assertions.
+    #[derive(Default)]
+    pub struct StubEvents {
+        pub events: Mutex<Vec<MeetingEvent>>,
+    }
+
+    impl MeetingEvents for StubEvents {
+        fn emit(&self, ev: MeetingEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(ev);
+        }
+    }
+}
+
+// ─── The engine: drives the state machine over the trait boundaries ───
+
+/// Owns the meeting state machine and segment scheduling. Generic over the
+/// four host boundaries so the same logic runs on desktop and (future)
+/// wearable hosts. The desktop host owns one of these inside `MeetingHandle`.
+pub struct MeetingEngine<A: AudioSource, T: Transcriber, S: MeetingStore, E: MeetingEvents> {
+    audio: A,
+    transcriber: T,
+    store: S,
+    events: E,
+    config: MeetingConfig,
+
+    state: MeetingState,
+    session_id: i64,
+    sample_rate: u32,
+
+    /// PCM accumulated for the segment currently being recorded.
+    segment_buffer: Vec<u8>,
+    /// Total PCM bytes captured across the whole meeting (for elapsed time).
+    total_bytes: u64,
+    /// Start offset (ms) of the in-progress segment.
+    current_segment_start_ms: u64,
+    /// Index of the next segment to be cut.
+    next_seg_index: u32,
+    /// Finished segments awaiting transcription (file-based / deferred mode).
+    pending: Vec<Segment>,
+    /// Transcribed text per segment index, in order, for the merged full text.
+    transcribed: Vec<(u32, String)>,
+}
+
+impl<A: AudioSource, T: Transcriber, S: MeetingStore, E: MeetingEvents> MeetingEngine<A, T, S, E> {
+    pub fn new(
+        audio: A,
+        transcriber: T,
+        store: S,
+        events: E,
+        config: MeetingConfig,
+        sample_rate: u32,
+    ) -> Self {
+        Self {
+            audio,
+            transcriber,
+            store,
+            events,
+            config,
+            state: MeetingState::Idle,
+            session_id: 0,
+            sample_rate,
+            segment_buffer: Vec::new(),
+            total_bytes: 0,
+            current_segment_start_ms: 0,
+            next_seg_index: 0,
+            pending: Vec::new(),
+            transcribed: Vec::new(),
+        }
+    }
+
+    pub fn state(&self) -> MeetingState {
+        self.state
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(self.state, MeetingState::Recording | MeetingState::Finalizing)
+    }
+
+    fn set_state(&mut self, s: MeetingState) {
+        self.state = s;
+        self.events.emit(MeetingEvent::State(s));
+    }
+
+    /// Total audio captured so far, in milliseconds.
+    pub fn elapsed_ms(&self) -> u64 {
+        pcm_bytes_to_ms(self.total_bytes, self.sample_rate)
+    }
+
+    /// Begin a meeting: create the session row and enter `Recording`.
+    pub fn start(&mut self, meta: SessionMeta) -> Result<(), String> {
+        if self.state != MeetingState::Idle {
+            return Err("meeting already in progress".to_string());
+        }
+        self.session_id = self.store.create_session(meta)?;
+        self.set_state(MeetingState::Recording);
+        Ok(())
+    }
+
+    /// Pull all currently-available audio, append to the segment buffer, and
+    /// cut / finalize as the timing thresholds dictate. Call this on a timer.
+    /// Returns `true` if the meeting auto-finalized during this tick.
+    pub async fn tick(&mut self) -> Result<bool, String> {
+        if self.state != MeetingState::Recording {
+            return Ok(false);
+        }
+
+        while let Some(chunk) = self.audio.try_recv() {
+            self.total_bytes += chunk.bytes.len() as u64;
+            self.segment_buffer.extend_from_slice(&chunk.bytes);
+        }
+
+        // Hard cap → finalize the whole meeting.
+        if should_auto_finalize(self.elapsed_ms(), &self.config) {
+            self.finalize().await?;
+            return Ok(true);
+        }
+
+        // Interval reached → cut one segment per interval's worth of audio,
+        // looping in case a slow tick accumulated several intervals at once.
+        loop {
+            let seg_bytes = self.segment_buffer.len() as u64;
+            let seg_ms = pcm_bytes_to_ms(seg_bytes, self.sample_rate);
+            if !should_cut_segment(seg_ms, &self.config) {
+                break;
+            }
+            self.cut_segment().await?;
+        }
+
+        Ok(false)
+    }
+
+    /// Close the in-progress segment, hand it downstream, and start a fresh
+    /// buffer. Audio capture is never paused, so no samples are dropped at the
+    /// boundary (design §2.2).
+    ///
+    /// Peels off exactly one `segment_interval_secs` worth of PCM and retains
+    /// the remainder for the next segment, so segmentation stays deterministic
+    /// regardless of how much audio a single tick happened to drain.
+    async fn cut_segment(&mut self) -> Result<(), String> {
+        let interval_bytes =
+            (bytes_per_sec(self.sample_rate) * self.config.segment_interval_secs as u64) as usize;
+        let take = interval_bytes.min(self.segment_buffer.len());
+        let pcm: Vec<u8> = self.segment_buffer.drain(..take).collect();
+        let seg_ms = pcm_bytes_to_ms(pcm.len() as u64, self.sample_rate);
+        let start_ms = self.current_segment_start_ms;
+        let end_ms = start_ms + seg_ms;
+        let meta = SegmentMeta {
+            seg_index: self.next_seg_index,
+            start_ms,
+            end_ms,
+        };
+        self.next_seg_index += 1;
+        self.current_segment_start_ms = end_ms;
+        self.handoff_segment(Segment { meta, pcm }).await
+    }
+
+    /// Route a closed segment per provider type (design §3C):
+    /// streaming → transcribe now; file-based → queue for finalize.
+    async fn handoff_segment(&mut self, seg: Segment) -> Result<(), String> {
+        let idx = seg.meta.seg_index;
+        self.store.upsert_segment(
+            self.session_id,
+            SegmentRow {
+                seg_index: idx,
+                start_ms: seg.meta.start_ms,
+                end_ms: seg.meta.end_ms,
+                status: SegStatus::Pending,
+                text: String::new(),
+            },
+        )?;
+
+        if self.transcriber.is_streaming() {
+            self.transcribe_now(seg).await?;
+        } else {
+            self.events.emit(MeetingEvent::Segment {
+                idx,
+                status: SegStatus::Pending,
+                text: String::new(),
+            });
+            self.pending.push(seg);
+        }
+        Ok(())
+    }
+
+    /// Transcribe a single segment immediately and persist the result.
+    async fn transcribe_now(&mut self, seg: Segment) -> Result<(), String> {
+        let idx = seg.meta.seg_index;
+        self.events.emit(MeetingEvent::Segment {
+            idx,
+            status: SegStatus::Transcribing,
+            text: String::new(),
+        });
+        match self
+            .transcriber
+            .transcribe_segment(&seg.pcm, self.sample_rate)
+            .await
+        {
+            Ok(text) => {
+                self.store.upsert_segment(
+                    self.session_id,
+                    SegmentRow {
+                        seg_index: idx,
+                        start_ms: seg.meta.start_ms,
+                        end_ms: seg.meta.end_ms,
+                        status: SegStatus::Done,
+                        text: text.clone(),
+                    },
+                )?;
+                self.transcribed.push((idx, text.clone()));
+                self.events.emit(MeetingEvent::Segment {
+                    idx,
+                    status: SegStatus::Done,
+                    text,
+                });
+                Ok(())
+            }
+            Err(e) => {
+                self.store.upsert_segment(
+                    self.session_id,
+                    SegmentRow {
+                        seg_index: idx,
+                        start_ms: seg.meta.start_ms,
+                        end_ms: seg.meta.end_ms,
+                        status: SegStatus::Failed,
+                        text: String::new(),
+                    },
+                )?;
+                self.events.emit(MeetingEvent::Segment {
+                    idx,
+                    status: SegStatus::Failed,
+                    text: String::new(),
+                });
+                self.events.emit(MeetingEvent::Error(e.clone()));
+                Err(e)
+            }
+        }
+    }
+
+    /// Finalize: flush the trailing buffer, transcribe everything still
+    /// pending, merge the full text, and archive. Works for both a manual stop
+    /// and the auto cap. Idempotent-ish: a no-op if not recording.
+    pub async fn finalize(&mut self) -> Result<(), String> {
+        if self.state != MeetingState::Recording {
+            return Ok(());
+        }
+        self.set_state(MeetingState::Finalizing);
+
+        // Drain any audio that arrived since the last tick.
+        while let Some(chunk) = self.audio.try_recv() {
+            self.total_bytes += chunk.bytes.len() as u64;
+            self.segment_buffer.extend_from_slice(&chunk.bytes);
+        }
+
+        // Emit the trailing buffer as a final segment when it qualifies.
+        let tail = std::mem::take(&mut self.segment_buffer);
+        let tail_ms = pcm_bytes_to_ms(tail.len() as u64, self.sample_rate);
+        if should_emit_on_finalize(tail_ms, self.next_seg_index, &self.config) {
+            let start_ms = self.current_segment_start_ms;
+            let meta = SegmentMeta {
+                seg_index: self.next_seg_index,
+                start_ms,
+                end_ms: start_ms + tail_ms,
+            };
+            self.next_seg_index += 1;
+            self.current_segment_start_ms = meta.end_ms;
+            self.handoff_segment(Segment { meta, pcm: tail }).await?;
+        }
+
+        // File-based mode: everything is still queued — transcribe it now.
+        let pending = std::mem::take(&mut self.pending);
+        let total = pending.len() as u32;
+        let mut done = 0u32;
+        for seg in pending {
+            self.transcribe_now(seg).await?;
+            done += 1;
+            self.events.emit(MeetingEvent::Progress { done, total });
+        }
+
+        // Merge transcripts in segment order into the session full text.
+        self.transcribed.sort_by_key(|(idx, _)| *idx);
+        let full_text = self
+            .transcribed
+            .iter()
+            .map(|(_, t)| t.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let duration_ms = self.elapsed_ms();
+        self.store
+            .finalize_session(self.session_id, &full_text, duration_ms)?;
+        self.set_state(MeetingState::Archived);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stub::*;
+    use super::*;
+
+    fn cfg() -> MeetingConfig {
+        // 5 s segments, 12 s cap, 2 s minimum — scaled down for fast tests
+        // while exercising the exact same arithmetic as the production knobs.
+        MeetingConfig {
+            segment_interval_secs: 5,
+            max_meeting_secs: 12,
+            min_segment_secs: 2,
+        }
+    }
+
+    fn secs_of_pcm(secs: u32) -> Vec<u8> {
+        vec![0u8; (bytes_per_sec(PCM_SAMPLE_RATE) as usize) * secs as usize]
+    }
+
+    fn chunk(secs: u32) -> PcmChunk {
+        PcmChunk {
+            bytes: secs_of_pcm(secs),
+            sample_rate: PCM_SAMPLE_RATE,
+        }
+    }
+
+    fn meta() -> SessionMeta {
+        SessionMeta {
+            created_at: "2026-06-24T00:00:00".to_string(),
+            stt_provider: "glm-asr".to_string(),
+            language: None,
+        }
+    }
+
+    // ── Pure timing-function tests ──
+
+    #[test]
+    fn bytes_to_ms_round_trips_one_second() {
+        let one_sec = bytes_per_sec(PCM_SAMPLE_RATE);
+        assert_eq!(pcm_bytes_to_ms(one_sec, PCM_SAMPLE_RATE), 1000);
+    }
+
+    #[test]
+    fn cut_triggers_exactly_at_interval_boundary() {
+        let c = cfg(); // 5 s
+        assert!(!should_cut_segment(4_999, &c));
+        assert!(should_cut_segment(5_000, &c));
+        assert!(should_cut_segment(5_001, &c));
+    }
+
+    #[test]
+    fn auto_finalize_triggers_at_cap() {
+        let c = cfg(); // 12 s
+        assert!(!should_auto_finalize(11_999, &c));
+        assert!(should_auto_finalize(12_000, &c));
+    }
+
+    #[test]
+    fn production_defaults_match_design() {
+        let c = MeetingConfig::default();
+        assert_eq!(c.segment_interval_secs, 300); // 5 min
+        assert_eq!(c.max_meeting_secs, 10800); // 3 hr
+        assert_eq!(c.min_segment_secs, 15);
+        assert!(should_cut_segment(300_000, &c));
+        assert!(should_auto_finalize(10_800_000, &c));
+    }
+
+    #[test]
+    fn finalize_emits_short_first_segment_but_drops_short_tail() {
+        let c = cfg(); // min 2 s
+        // Only segment, short → still emit.
+        assert!(should_emit_on_finalize(1_000, 0, &c));
+        // Short tail after prior segments → drop.
+        assert!(!should_emit_on_finalize(1_000, 3, &c));
+        // Long tail after prior segments → emit.
+        assert!(should_emit_on_finalize(2_000, 3, &c));
+    }
+
+    // ── Engine integration tests over the stubs ──
+
+    #[tokio::test]
+    async fn manual_stop_finalizes_in_flight_segment() {
+        // 3 s of audio, well under the 5 s cut → one tail segment on finalize.
+        let audio = VecAudioSource::new(vec![chunk(3)]);
+        let store = StubStore::default();
+        let events = StubEvents::default();
+        let mut engine = MeetingEngine::new(
+            audio,
+            StubTranscriber::new(false),
+            store,
+            events,
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+
+        engine.start(meta()).unwrap();
+        assert_eq!(engine.state(), MeetingState::Recording);
+        engine.tick().await.unwrap(); // pulls audio, no cut yet
+        engine.finalize().await.unwrap(); // manual stop
+
+        assert_eq!(engine.state(), MeetingState::Archived);
+        // Exactly one segment got transcribed and stored as done.
+        let segs = engine.store.segments.lock().unwrap();
+        assert!(segs.iter().any(|(_, s)| s.status == SegStatus::Done));
+        let finalized = engine.store.finalized.lock().unwrap();
+        assert_eq!(finalized.len(), 1);
+        assert!(!finalized[0].1.is_empty());
+    }
+
+    #[tokio::test]
+    async fn file_based_provider_cuts_at_interval_and_defers_transcription() {
+        // 11 s total → two 5 s cuts (the cut loop peels one interval at a time)
+        // + 1 s tail dropped on finalize (tail < 2 s min, prior segments exist).
+        let audio = VecAudioSource::new(vec![chunk(5), chunk(5), chunk(1)]);
+        let transcriber = StubTranscriber::new(false); // file-based
+        let mut engine = MeetingEngine::new(
+            audio,
+            transcriber,
+            StubStore::default(),
+            StubEvents::default(),
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+
+        engine.start(meta()).unwrap();
+        // A single tick drains all queued audio (11 s) and the cut loop peels
+        // two 5 s segments, leaving a 1 s remainder in the buffer.
+        engine.tick().await.unwrap();
+
+        // File-based: nothing transcribed until finalize, even though segments
+        // were already cut and queued.
+        assert_eq!(engine.transcriber.calls.lock().unwrap().len(), 0);
+
+        engine.finalize().await.unwrap();
+        // Two full segments transcribed at finalize; 1 s tail dropped.
+        assert_eq!(engine.transcriber.calls.lock().unwrap().len(), 2);
+        assert_eq!(engine.state(), MeetingState::Archived);
+    }
+
+    #[tokio::test]
+    async fn streaming_provider_transcribes_each_segment_immediately() {
+        let audio = VecAudioSource::new(vec![chunk(5)]);
+        let transcriber = StubTranscriber::new(true); // streaming
+        let mut engine = MeetingEngine::new(
+            audio,
+            transcriber,
+            StubStore::default(),
+            StubEvents::default(),
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+
+        engine.start(meta()).unwrap();
+        engine.tick().await.unwrap(); // 5 s → immediate cut + transcribe
+
+        // Streaming: the segment was transcribed during recording.
+        assert_eq!(engine.transcriber.calls.lock().unwrap().len(), 1);
+
+        engine.finalize().await.unwrap();
+        assert_eq!(engine.state(), MeetingState::Archived);
+    }
+
+    #[tokio::test]
+    async fn auto_finalize_at_cap_without_manual_stop() {
+        // 12 s in one chunk → first tick cuts one 5 s segment? No: one tick
+        // pulls all 12 s, elapsed 12 s ≥ cap → auto-finalize fires first.
+        let audio = VecAudioSource::new(vec![chunk(12)]);
+        let mut engine = MeetingEngine::new(
+            audio,
+            StubTranscriber::new(false),
+            StubStore::default(),
+            StubEvents::default(),
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+
+        engine.start(meta()).unwrap();
+        let auto = engine.tick().await.unwrap();
+        assert!(auto, "tick should report auto-finalize at the cap");
+        assert_eq!(engine.state(), MeetingState::Archived);
+        assert_eq!(engine.store.finalized.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn full_text_merges_segments_in_order() {
+        let audio = VecAudioSource::new(vec![chunk(5), chunk(5)]);
+        let mut engine = MeetingEngine::new(
+            audio,
+            StubTranscriber::new(true), // streaming so both get text
+            StubStore::default(),
+            StubEvents::default(),
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+
+        engine.start(meta()).unwrap();
+        engine.tick().await.unwrap(); // drains 10 s → cut loop peels two 5 s segments
+        engine.finalize().await.unwrap();
+
+        let finalized = engine.store.finalized.lock().unwrap();
+        let full = &finalized[0].1;
+        // Two segments joined by a blank line.
+        assert!(full.contains("\n\n"));
+        assert_eq!(full.matches("[seg").count(), 2);
+    }
+}

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -1,0 +1,217 @@
+//! Meeting / long-recording mode (MEL-75 — recording half).
+//!
+//! Layout mirrors the MEL-74 design §5.4 module boundaries:
+//! - [`engine`]  — UI-agnostic core (state machine + segmentation timing).
+//!                 Zero Tauri / SQLite / cpal dependencies; portable to a
+//!                 future wearable host as `meeting_core`.
+//! - [`adapters`] — desktop glue (cpal capture channel, Tauri event bus).
+//! - [`MeetingHandle`] — Tauri state object that owns the engine, drives the
+//!                 segment timer, and enforces mic exclusivity with the
+//!                 instant-transcription pipeline.
+//!
+//! Transcription + SQLite persistence are MEL-76. MEL-75 wires the engine with
+//! the in-memory stubs (`engine::stub`) so the recording path runs end-to-end
+//! today; MEL-76 swaps in the real `Transcriber` / `MeetingStore`.
+
+pub mod adapters;
+pub mod engine;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tauri::Manager;
+
+use crate::audio::{AudioCaptureHandle, AudioConfig};
+use engine::{MeetingConfig, MeetingState, SessionMeta};
+
+/// How often the segment timer pulls audio and checks the cut / cap
+/// thresholds. 250 ms is fine-grained enough that a 5-min boundary is hit
+/// within a quarter second while costing almost nothing.
+const TICK_INTERVAL_MS: u64 = 250;
+
+/// The concrete engine type MEL-75 ships: real audio + Tauri events, but
+/// **stub** transcriber + store (the real ones arrive in MEL-76).
+type DesktopEngine = engine::MeetingEngine<
+    adapters::ChannelAudioSource,
+    engine::stub::StubTranscriber,
+    engine::stub::StubStore,
+    adapters::TauriMeetingEvents,
+>;
+
+/// Tauri-managed handle for the meeting recording mode. Lives alongside
+/// `PipelineHandle` in app state; the two never record at the same time
+/// (design §1.2).
+pub struct MeetingHandle {
+    app_handle: tauri::AppHandle,
+    config: MeetingConfig,
+    /// Mirrors the engine state without locking the engine, so the instant
+    /// pipeline's exclusivity guard is a cheap atomic read.
+    active: Arc<AtomicBool>,
+    /// The running engine + its capture handle. `None` when idle.
+    inner: Arc<Mutex<Option<RunningMeeting>>>,
+    /// Serializes start()/stop() the same way `PipelineHandle::pipeline_lock`
+    /// does, so a fast start→stop can't read half-initialized state.
+    op_lock: tokio::sync::Mutex<()>,
+}
+
+struct RunningMeeting {
+    engine: DesktopEngine,
+    capture: AudioCaptureHandle,
+}
+
+impl MeetingHandle {
+    pub fn new(app_handle: tauri::AppHandle) -> Self {
+        Self {
+            app_handle,
+            config: MeetingConfig::default(),
+            active: Arc::new(AtomicBool::new(false)),
+            inner: Arc::new(Mutex::new(None)),
+            op_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// True while a meeting is recording or finalizing. The instant pipeline
+    /// reads this to refuse starting (design §1.2).
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    /// Start a meeting recording.
+    ///
+    /// Refuses if a meeting is already active **or** the instant pipeline is
+    /// not idle — the two modes must never share the mic (design §1.2).
+    pub async fn start(&self, stt_provider: String, language: Option<String>) -> Result<(), String> {
+        let _guard = self.op_lock.lock().await;
+
+        if self.is_active() {
+            return Err("A meeting recording is already in progress".to_string());
+        }
+
+        // Mic exclusivity: the instant-transcription pipeline must be idle.
+        if let Some(pipeline) = self
+            .app_handle
+            .try_state::<crate::pipeline::PipelineHandle>()
+        {
+            if pipeline.current_state() != crate::pipeline::PipelineState::Idle {
+                return Err(
+                    "Instant dictation is active; finish it before starting a meeting".to_string(),
+                );
+            }
+        }
+
+        // Reuse the existing cpal capture pipeline; only the consumer differs.
+        let (capture, audio_rx) = AudioCaptureHandle::start(AudioConfig::default())
+            .map_err(|e| format!("Audio capture failed: {e}"))?;
+
+        let sample_rate = AudioConfig::default().sample_rate;
+        let audio = adapters::ChannelAudioSource::new(audio_rx, sample_rate);
+        let events = adapters::TauriMeetingEvents::new(self.app_handle.clone());
+
+        // MEL-76 replaces these two stubs with the real SttProvider-backed
+        // transcriber and the SQLite-backed store.
+        let transcriber = engine::stub::StubTranscriber::new(false);
+        let store = engine::stub::StubStore::default();
+
+        let mut eng =
+            engine::MeetingEngine::new(audio, transcriber, store, events, self.config, sample_rate);
+
+        let created_at = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        eng.start(SessionMeta {
+            created_at,
+            stt_provider,
+            language,
+        })?;
+
+        *self.inner.lock().unwrap_or_else(|e| e.into_inner()) = Some(RunningMeeting {
+            engine: eng,
+            capture,
+        });
+        self.active.store(true, Ordering::SeqCst);
+
+        self.spawn_tick_loop();
+        Ok(())
+    }
+
+    /// Manually stop and finalize the in-flight meeting (design §1.3).
+    pub async fn stop(&self) -> Result<(), String> {
+        let _guard = self.op_lock.lock().await;
+        self.finalize_and_clear().await
+    }
+
+    /// Drive the engine tick loop on a timer until the engine leaves the
+    /// `Recording` state (manual stop or the 3-hour auto-cap).
+    fn spawn_tick_loop(&self) {
+        let inner = self.inner.clone();
+        let active = self.active.clone();
+        let app_handle = self.app_handle.clone();
+        tauri::async_runtime::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(TICK_INTERVAL_MS)).await;
+
+                // Take the engine out, tick it, put it back. The engine isn't
+                // Send-bound across await inside the lock, so we briefly own it.
+                let mut running = {
+                    let mut guard = inner.lock().unwrap_or_else(|e| e.into_inner());
+                    match guard.take() {
+                        Some(r) => r,
+                        None => break, // stopped elsewhere
+                    }
+                };
+
+                if running.engine.state() != MeetingState::Recording {
+                    // Auto-finalize already happened, or we're done.
+                    running.capture.stop();
+                    active.store(false, Ordering::SeqCst);
+                    break;
+                }
+
+                let auto_finalized = match running.engine.tick().await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::error!("Meeting tick error: {}", e);
+                        let _ = app_handle.emit_meeting_error(&e);
+                        running.capture.stop();
+                        active.store(false, Ordering::SeqCst);
+                        break;
+                    }
+                };
+
+                if auto_finalized {
+                    running.capture.stop();
+                    active.store(false, Ordering::SeqCst);
+                    tracing::info!("Meeting auto-finalized at duration cap");
+                    break;
+                }
+
+                // Put the engine back for the next tick.
+                *inner.lock().unwrap_or_else(|e| e.into_inner()) = Some(running);
+            }
+        });
+    }
+
+    /// Finalize the current meeting (if any) and clear state.
+    async fn finalize_and_clear(&self) -> Result<(), String> {
+        let mut running = match self.inner.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            Some(r) => r,
+            None => return Ok(()), // already idle
+        };
+
+        let result = running.engine.finalize().await;
+        running.capture.stop();
+        self.active.store(false, Ordering::SeqCst);
+        result
+    }
+}
+
+/// Small extension so the tick loop can emit a meeting error without pulling
+/// `Emitter` into scope at every call site.
+trait MeetingErrorEmit {
+    fn emit_meeting_error(&self, message: &str) -> Result<(), tauri::Error>;
+}
+
+impl MeetingErrorEmit for tauri::AppHandle {
+    fn emit_meeting_error(&self, message: &str) -> Result<(), tauri::Error> {
+        use tauri::Emitter;
+        self.emit("meeting:error", message)
+    }
+}

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -29,12 +29,13 @@ use engine::{MeetingConfig, MeetingState, SessionMeta};
 /// within a quarter second while costing almost nothing.
 const TICK_INTERVAL_MS: u64 = 250;
 
-/// The concrete engine type MEL-75 ships: real audio + Tauri events, but
-/// **stub** transcriber + store (the real ones arrive in MEL-76).
+/// The concrete engine type the desktop host runs: real cpal audio, real
+/// `SttProvider`-backed transcriber, real SQLite store, and Tauri events
+/// (MEL-76 swapped in the real transcriber + store over MEL-75's stubs).
 type DesktopEngine = engine::MeetingEngine<
     adapters::ChannelAudioSource,
-    engine::stub::StubTranscriber,
-    engine::stub::StubStore,
+    adapters::SttTranscriber,
+    crate::storage::meeting::MeetingDbStore,
     adapters::TauriMeetingEvents,
 >;
 
@@ -76,6 +77,76 @@ impl MeetingHandle {
         self.active.load(Ordering::SeqCst)
     }
 
+    /// Build the real STT transcriber for this meeting from the app's STT
+    /// settings. Mirrors the instant pipeline's provider/key/custom-config
+    /// resolution (`pipeline::run` §P0-3) so meeting transcription uses the
+    /// exact same provider the user configured.
+    async fn build_transcriber(
+        &self,
+        provider_name: &str,
+        language: Option<String>,
+    ) -> Result<adapters::SttTranscriber, String> {
+        use crate::stt::config;
+
+        let cfg = self
+            .app_handle
+            .state::<crate::storage::ConfigManager>()
+            .load()
+            .await
+            .map_err(|e| format!("Failed to load config: {e}"))?;
+
+        // Custom-Whisper needs its base URL + model resolved into a config.
+        let custom_whisper_config = if provider_name == config::CUSTOM_WHISPER_PROVIDER {
+            Some(
+                config::build_custom_whisper_config(&cfg.stt_custom_base_url, &cfg.stt_custom_model)?,
+            )
+        } else {
+            None
+        };
+
+        // API key source matches the pipeline: cloud → session token,
+        // custom-whisper → its own key, everything else → the hosted key.
+        let api_key = if provider_name == "cloud" {
+            self.app_handle
+                .state::<crate::SessionTokenStore>()
+                .0
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        } else if provider_name == config::CUSTOM_WHISPER_PROVIDER {
+            cfg.stt_custom_api_key.clone()
+        } else {
+            cfg.stt_api_key.clone()
+        };
+
+        if config::stt_provider_requires_api_key(provider_name) && api_key.is_empty() {
+            return Err(
+                "STT API key is not configured. Please set it in Settings -> Speech Recognition."
+                    .to_string(),
+            );
+        }
+
+        let stt_config = crate::stt::SttConfig {
+            api_key,
+            language,
+            smart_format: true,
+            sample_rate: AudioConfig::default().sample_rate,
+        };
+
+        let client = self
+            .app_handle
+            .try_state::<reqwest::Client>()
+            .map(|c| (*c).clone())
+            .unwrap_or_default();
+
+        Ok(adapters::SttTranscriber::new(
+            provider_name.to_string(),
+            stt_config,
+            custom_whisper_config,
+            client,
+        ))
+    }
+
     /// Start a meeting recording.
     ///
     /// Refuses if a meeting is already active **or** the instant pipeline is
@@ -99,6 +170,19 @@ impl MeetingHandle {
             }
         }
 
+        // Build the real STT transcriber from the app's STT config before we
+        // open the mic, so a misconfiguration fails fast.
+        let transcriber = self
+            .build_transcriber(&stt_provider, language.clone())
+            .await?;
+
+        // The SQLite meeting store is managed Tauri state; clone the handle.
+        let store = self
+            .app_handle
+            .try_state::<crate::storage::meeting::MeetingDbStore>()
+            .map(|s| (*s).clone())
+            .ok_or_else(|| "Meeting store is not initialized".to_string())?;
+
         // Reuse the existing cpal capture pipeline; only the consumer differs.
         let (capture, audio_rx) = AudioCaptureHandle::start(AudioConfig::default())
             .map_err(|e| format!("Audio capture failed: {e}"))?;
@@ -106,11 +190,6 @@ impl MeetingHandle {
         let sample_rate = AudioConfig::default().sample_rate;
         let audio = adapters::ChannelAudioSource::new(audio_rx, sample_rate);
         let events = adapters::TauriMeetingEvents::new(self.app_handle.clone());
-
-        // MEL-76 replaces these two stubs with the real SttProvider-backed
-        // transcriber and the SQLite-backed store.
-        let transcriber = engine::stub::StubTranscriber::new(false);
-        let store = engine::stub::StubStore::default();
 
         let mut eng =
             engine::MeetingEngine::new(audio, transcriber, store, events, self.config, sample_rate);

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -374,6 +374,17 @@ impl PipelineHandle {
     }
 
     pub async fn start(&self) -> Result<()> {
+        // Mic exclusivity: a meeting recording owns the mic exclusively, so
+        // instant dictation early-returns while one is active (MEL-74 §1.2).
+        // This is the only cross-mode coupling on the instant-mode path and is
+        // a pure early-return guard — existing behavior is otherwise untouched.
+        if let Some(meeting) = self.app_handle.try_state::<crate::meeting::MeetingHandle>() {
+            if meeting.is_active() {
+                tracing::info!("Ignoring instant recording start — a meeting is recording");
+                return Ok(());
+            }
+        }
+
         // Hold pipeline_lock for the entire setup so stop() cannot read
         // partially-initialised state (preloaded_config, audio_handle, etc.).
         let _guard = self.pipeline_lock.lock().await;

--- a/src-tauri/src/storage/meeting.rs
+++ b/src-tauri/src/storage/meeting.rs
@@ -1,0 +1,690 @@
+//! SQLite persistence for the meeting / long-recording mode (MEL-76).
+//!
+//! Two new tables (`meeting_session` + `meeting_segment`) per the MEL-74
+//! storage model. The existing instant-dictation `history` table is left
+//! completely untouched — meeting transcripts never mix into it.
+//!
+//! `MeetingDbStore` is the SQLite-backed implementation of the engine's
+//! `meeting::engine::MeetingStore` trait (the write path used while a meeting
+//! records). The read path (list sessions / read one full session / export)
+//! lives on the same struct as plain async methods consumed by the Tauri
+//! query commands and the frontend (MEL-77).
+
+use anyhow::Result;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::meeting::engine::{MeetingStore, SegStatus, SegmentRow, SessionMeta};
+
+/// A meeting session row (header), without its segments.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeetingSession {
+    pub id: i64,
+    pub created_at: String,
+    pub stt_provider: String,
+    pub language: Option<String>,
+    /// Merged transcript of all segments; empty until the meeting is finalized.
+    pub full_text: String,
+    pub duration_ms: i64,
+    /// "recording" while in progress, "archived" once finalized.
+    pub status: String,
+}
+
+/// A single transcribed segment row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeetingSegment {
+    pub seg_index: i64,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    /// "pending" | "transcribing" | "done" | "failed".
+    pub status: String,
+    pub text: String,
+}
+
+/// A full meeting: header + ordered segments. The "read one meeting in full"
+/// shape returned to the UI and used for export.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeetingDetail {
+    #[serde(flatten)]
+    pub session: MeetingSession,
+    pub segments: Vec<MeetingSegment>,
+}
+
+fn seg_status_str(status: SegStatus) -> &'static str {
+    match status {
+        SegStatus::Pending => "pending",
+        SegStatus::Transcribing => "transcribing",
+        SegStatus::Done => "done",
+        SegStatus::Failed => "failed",
+    }
+}
+
+/// SQLite store for meeting sessions and segments.
+///
+/// Cloneable handle (the engine holds one clone via the trait, the Tauri
+/// query commands hold another via managed state) sharing a single connection.
+#[derive(Clone)]
+pub struct MeetingDbStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl MeetingDbStore {
+    pub fn new(db_path: PathBuf) -> Result<Self> {
+        let conn = Connection::open(&db_path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS meeting_session (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL,
+                stt_provider TEXT NOT NULL DEFAULT '',
+                language TEXT,
+                full_text TEXT NOT NULL DEFAULT '',
+                duration_ms INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'recording'
+            );
+            CREATE TABLE IF NOT EXISTS meeting_segment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id INTEGER NOT NULL,
+                seg_index INTEGER NOT NULL,
+                start_ms INTEGER NOT NULL DEFAULT 0,
+                end_ms INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'pending',
+                text TEXT NOT NULL DEFAULT '',
+                UNIQUE(session_id, seg_index)
+            );
+            CREATE INDEX IF NOT EXISTS idx_meeting_segment_session
+                ON meeting_segment(session_id);",
+        )?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    // ─── Read path (query commands / export) ───
+
+    /// List meeting sessions, newest first. Segments are not loaded here.
+    pub async fn list_sessions(&self, limit: u32, offset: u32) -> Result<Vec<MeetingSession>> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        let mut stmt = conn.prepare(
+            "SELECT id, created_at, stt_provider, language, full_text, duration_ms, status
+             FROM meeting_session ORDER BY id DESC LIMIT ?1 OFFSET ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![limit, offset], row_to_session)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Read one meeting in full (header + ordered segments). `None` if the id
+    /// does not exist.
+    pub async fn get_session(&self, session_id: i64) -> Result<Option<MeetingDetail>> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+
+        let session = conn
+            .query_row(
+                "SELECT id, created_at, stt_provider, language, full_text, duration_ms, status
+                 FROM meeting_session WHERE id = ?1",
+                rusqlite::params![session_id],
+                row_to_session,
+            )
+            .ok();
+
+        let session = match session {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+
+        let mut stmt = conn.prepare(
+            "SELECT seg_index, start_ms, end_ms, status, text
+             FROM meeting_segment WHERE session_id = ?1 ORDER BY seg_index ASC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![session_id], |row| {
+            Ok(MeetingSegment {
+                seg_index: row.get(0)?,
+                start_ms: row.get(1)?,
+                end_ms: row.get(2)?,
+                status: row.get(3)?,
+                text: row.get(4)?,
+            })
+        })?;
+        let mut segments = Vec::new();
+        for r in rows {
+            segments.push(r?);
+        }
+
+        Ok(Some(MeetingDetail { session, segments }))
+    }
+
+    /// Delete a meeting session and its segments.
+    pub async fn delete_session(&self, session_id: i64) -> Result<()> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        conn.execute(
+            "DELETE FROM meeting_segment WHERE session_id = ?1",
+            rusqlite::params![session_id],
+        )?;
+        conn.execute(
+            "DELETE FROM meeting_session WHERE id = ?1",
+            rusqlite::params![session_id],
+        )?;
+        Ok(())
+    }
+}
+
+fn row_to_session(row: &rusqlite::Row) -> rusqlite::Result<MeetingSession> {
+    Ok(MeetingSession {
+        id: row.get(0)?,
+        created_at: row.get(1)?,
+        stt_provider: row.get(2)?,
+        language: row.get(3)?,
+        full_text: row.get(4)?,
+        duration_ms: row.get(5)?,
+        status: row.get(6)?,
+    })
+}
+
+// ─── Write path: engine MeetingStore trait impl (synchronous) ───
+
+impl MeetingStore for MeetingDbStore {
+    fn create_session(&self, meta: SessionMeta) -> Result<i64, String> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        conn.execute(
+            "INSERT INTO meeting_session (created_at, stt_provider, language, full_text, duration_ms, status)
+             VALUES (?1, ?2, ?3, '', 0, 'recording')",
+            rusqlite::params![meta.created_at, meta.stt_provider, meta.language],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    fn upsert_segment(&self, session_id: i64, seg: SegmentRow) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        conn.execute(
+            "INSERT INTO meeting_segment (session_id, seg_index, start_ms, end_ms, status, text)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(session_id, seg_index) DO UPDATE SET
+                start_ms = excluded.start_ms,
+                end_ms = excluded.end_ms,
+                status = excluded.status,
+                text = excluded.text",
+            rusqlite::params![
+                session_id,
+                seg.seg_index,
+                seg.start_ms,
+                seg.end_ms,
+                seg_status_str(seg.status),
+                seg.text,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    fn finalize_session(
+        &self,
+        session_id: i64,
+        full_text: &str,
+        duration_ms: u64,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        conn.execute(
+            "UPDATE meeting_session
+             SET full_text = ?2, duration_ms = ?3, status = 'archived'
+             WHERE id = ?1",
+            rusqlite::params![session_id, full_text, duration_ms as i64],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+/// Render a meeting's transcript as a Markdown document for export.
+pub fn render_markdown(detail: &MeetingDetail) -> String {
+    let s = &detail.session;
+    let mut out = String::new();
+    out.push_str(&format!("# Meeting {}\n\n", s.id));
+    out.push_str(&format!("- Date: {}\n", s.created_at));
+    out.push_str(&format!("- Provider: {}\n", s.stt_provider));
+    if let Some(lang) = &s.language {
+        out.push_str(&format!("- Language: {}\n", lang));
+    }
+    out.push_str(&format!(
+        "- Duration: {}\n\n",
+        format_duration(s.duration_ms),
+    ));
+    out.push_str("---\n\n");
+
+    if !s.full_text.trim().is_empty() {
+        out.push_str(&s.full_text);
+        out.push('\n');
+    } else {
+        // Fall back to per-segment text if the merged field is empty.
+        for seg in &detail.segments {
+            if !seg.text.trim().is_empty() {
+                out.push_str(&seg.text);
+                out.push_str("\n\n");
+            }
+        }
+    }
+    out
+}
+
+/// Render a meeting's transcript as plain text (no headers, just the body).
+pub fn render_plain_text(detail: &MeetingDetail) -> String {
+    let s = &detail.session;
+    if !s.full_text.trim().is_empty() {
+        return s.full_text.clone();
+    }
+    detail
+        .segments
+        .iter()
+        .map(|seg| seg.text.as_str())
+        .filter(|t| !t.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn format_duration(ms: i64) -> String {
+    let total_secs = (ms / 1000).max(0);
+    let h = total_secs / 3600;
+    let m = (total_secs % 3600) / 60;
+    let sec = total_secs % 60;
+    if h > 0 {
+        format!("{h}h {m}m {sec}s")
+    } else {
+        format!("{m}m {sec}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meeting::engine::{SegStatus, SegmentRow, SessionMeta};
+
+    fn store() -> MeetingDbStore {
+        // In-memory DB shared across the single connection — fine for tests.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE meeting_session (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL,
+                stt_provider TEXT NOT NULL DEFAULT '',
+                language TEXT,
+                full_text TEXT NOT NULL DEFAULT '',
+                duration_ms INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'recording'
+            );
+            CREATE TABLE meeting_segment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id INTEGER NOT NULL,
+                seg_index INTEGER NOT NULL,
+                start_ms INTEGER NOT NULL DEFAULT 0,
+                end_ms INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'pending',
+                text TEXT NOT NULL DEFAULT '',
+                UNIQUE(session_id, seg_index)
+            );",
+        )
+        .unwrap();
+        MeetingDbStore {
+            conn: Arc::new(Mutex::new(conn)),
+        }
+    }
+
+    fn meta() -> SessionMeta {
+        SessionMeta {
+            created_at: "2026-06-24T10:00:00".to_string(),
+            stt_provider: "glm-asr".to_string(),
+            language: Some("zh".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_upsert_finalize_round_trips_full_meeting() {
+        let store = store();
+        let id = store.create_session(meta()).unwrap();
+        assert_eq!(id, 1);
+
+        // Two segments persisted as pending, then upserted to done.
+        store
+            .upsert_segment(
+                id,
+                SegmentRow {
+                    seg_index: 0,
+                    start_ms: 0,
+                    end_ms: 5000,
+                    status: SegStatus::Pending,
+                    text: String::new(),
+                },
+            )
+            .unwrap();
+        store
+            .upsert_segment(
+                id,
+                SegmentRow {
+                    seg_index: 0,
+                    start_ms: 0,
+                    end_ms: 5000,
+                    status: SegStatus::Done,
+                    text: "hello".to_string(),
+                },
+            )
+            .unwrap();
+        store
+            .upsert_segment(
+                id,
+                SegmentRow {
+                    seg_index: 1,
+                    start_ms: 5000,
+                    end_ms: 9000,
+                    status: SegStatus::Done,
+                    text: "world".to_string(),
+                },
+            )
+            .unwrap();
+
+        store.finalize_session(id, "hello\n\nworld", 9000).unwrap();
+
+        // Read it back in full.
+        let detail = store.get_session(id).await.unwrap().unwrap();
+        assert_eq!(detail.session.status, "archived");
+        assert_eq!(detail.session.full_text, "hello\n\nworld");
+        assert_eq!(detail.session.duration_ms, 9000);
+        // Upsert collapsed seg 0 to a single row (not duplicated).
+        assert_eq!(detail.segments.len(), 2);
+        assert_eq!(detail.segments[0].text, "hello");
+        assert_eq!(detail.segments[1].text, "world");
+    }
+
+    #[tokio::test]
+    async fn list_sessions_newest_first() {
+        let store = store();
+        let a = store.create_session(meta()).unwrap();
+        let b = store.create_session(meta()).unwrap();
+        let list = store.list_sessions(10, 0).await.unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].id, b);
+        assert_eq!(list[1].id, a);
+    }
+
+    #[tokio::test]
+    async fn get_missing_session_is_none() {
+        let store = store();
+        assert!(store.get_session(999).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_session_and_segments() {
+        let store = store();
+        let id = store.create_session(meta()).unwrap();
+        store
+            .upsert_segment(
+                id,
+                SegmentRow {
+                    seg_index: 0,
+                    start_ms: 0,
+                    end_ms: 1000,
+                    status: SegStatus::Done,
+                    text: "x".to_string(),
+                },
+            )
+            .unwrap();
+        store.delete_session(id).await.unwrap();
+        assert!(store.get_session(id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn export_renders_markdown_and_plain_text() {
+        let store = store();
+        let id = store.create_session(meta()).unwrap();
+        store.finalize_session(id, "line one\n\nline two", 65000).unwrap();
+        let detail = store.get_session(id).await.unwrap().unwrap();
+
+        let md = render_markdown(&detail);
+        assert!(md.contains("# Meeting 1"));
+        assert!(md.contains("glm-asr"));
+        assert!(md.contains("1m 5s"));
+        assert!(md.contains("line one"));
+
+        let txt = render_plain_text(&detail);
+        assert_eq!(txt, "line one\n\nline two");
+    }
+
+    #[test]
+    fn duration_formats_hours_and_minutes() {
+        assert_eq!(format_duration(0), "0m 0s");
+        assert_eq!(format_duration(65_000), "1m 5s");
+        assert_eq!(format_duration(3_661_000), "1h 1m 1s");
+    }
+}
+
+/// End-to-end acceptance: drive the real `MeetingEngine` over the real
+/// `MeetingDbStore` (the exact wiring `MeetingHandle` uses) and prove each
+/// MEL-76 acceptance box. Uses a fake transcriber so no cloud STT credential
+/// is needed — the transcription *logic* (both timings) is exercised in full.
+#[cfg(test)]
+mod e2e {
+    use super::*;
+    use crate::meeting::engine::{
+        bytes_per_sec, MeetingConfig, MeetingEngine, MeetingEvents, PcmChunk, SessionMeta,
+        Transcriber, PCM_SAMPLE_RATE,
+    };
+    use async_trait::async_trait;
+
+    /// Deterministic transcriber: returns a per-segment label, no network.
+    struct FakeTranscriber {
+        streaming: bool,
+    }
+
+    #[async_trait]
+    impl Transcriber for FakeTranscriber {
+        async fn transcribe_segment(&self, pcm: &[u8], _sr: u32) -> Result<String, String> {
+            Ok(format!("seg-{}b", pcm.len()))
+        }
+        fn is_streaming(&self) -> bool {
+            self.streaming
+        }
+    }
+
+    struct NullEvents;
+    impl MeetingEvents for NullEvents {
+        fn emit(&self, _ev: crate::meeting::engine::MeetingEvent) {}
+    }
+
+    /// Audio source that yields a fixed queue of chunks, then None.
+    struct VecAudio(std::collections::VecDeque<PcmChunk>);
+    impl crate::meeting::engine::AudioSource for VecAudio {
+        fn try_recv(&mut self) -> Option<PcmChunk> {
+            self.0.pop_front()
+        }
+    }
+
+    /// A db path in the OS temp dir, unique per test, removed on drop.
+    struct TempDb {
+        path: PathBuf,
+    }
+    impl TempDb {
+        fn new(tag: &str) -> Self {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("mel76-{tag}-{nanos}.db"));
+            Self { path }
+        }
+    }
+    impl Drop for TempDb {
+        fn drop(&mut self) {
+            // Best-effort cleanup of the db file and its WAL/SHM siblings.
+            for suffix in ["", "-wal", "-shm"] {
+                let _ = std::fs::remove_file(format!("{}{}", self.path.display(), suffix));
+            }
+        }
+    }
+
+    fn file_store(tag: &str) -> (MeetingDbStore, TempDb) {
+        let db = TempDb::new(tag);
+        // Init the instant-history table on the SAME db file, so we can prove
+        // meeting writes never touch it.
+        let history = crate::storage::HistoryStore::new(db.path.clone()).unwrap();
+        drop(history);
+        let store = MeetingDbStore::new(db.path.clone()).unwrap();
+        (store, db)
+    }
+
+    fn chunk(secs: u32) -> PcmChunk {
+        PcmChunk {
+            bytes: vec![0u8; bytes_per_sec(PCM_SAMPLE_RATE) as usize * secs as usize],
+            sample_rate: PCM_SAMPLE_RATE,
+        }
+    }
+
+    fn cfg() -> MeetingConfig {
+        // 5 s segments / 60 s cap / 2 s min — same arithmetic, fast.
+        MeetingConfig {
+            segment_interval_secs: 5,
+            max_meeting_secs: 60,
+            min_segment_secs: 2,
+        }
+    }
+
+    fn meta() -> SessionMeta {
+        SessionMeta {
+            created_at: "2026-06-24T12:00:00".to_string(),
+            stt_provider: "glm-asr".to_string(),
+            language: None,
+        }
+    }
+
+    // Acceptance: file-based provider → one-shot transcription at meeting end;
+    // transcript persists; one meeting reads back complete.
+    #[tokio::test]
+    async fn file_based_one_shot_persists_and_reads_back_complete() {
+        let (store, _dir) = file_store("oneshot");
+        let audio = VecAudio(vec![chunk(5), chunk(5), chunk(3)].into());
+        let mut engine = MeetingEngine::new(
+            audio,
+            FakeTranscriber { streaming: false },
+            store.clone(),
+            NullEvents,
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+
+        engine.start(meta()).unwrap();
+        engine.tick().await.unwrap(); // drains 13 s → cuts two 5 s segments
+        engine.finalize().await.unwrap(); // one-shot transcribe + 3 s tail
+
+        let detail = store.get_session(1).await.unwrap().unwrap();
+        assert_eq!(detail.session.status, "archived");
+        // Three segments: two 5 s cuts + the 3 s tail (≥ 2 s min).
+        assert_eq!(detail.segments.len(), 3);
+        assert!(detail.segments.iter().all(|s| s.status == "done"));
+        // Full text is the merged transcript and reads back non-empty.
+        assert!(!detail.session.full_text.is_empty());
+        assert_eq!(detail.session.full_text.matches("seg-").count(), 3);
+        assert!(detail.session.duration_ms > 0);
+    }
+
+    // Acceptance: streaming provider → each segment transcribed as it is cut
+    // (during recording), still persists and reads back complete.
+    #[tokio::test]
+    async fn streaming_interval_transcribes_each_segment_during_recording() {
+        let (store, _dir) = file_store("streaming");
+        let audio = VecAudio(vec![chunk(5), chunk(5)].into());
+        let mut engine = MeetingEngine::new(
+            audio,
+            FakeTranscriber { streaming: true },
+            store.clone(),
+            NullEvents,
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+
+        engine.start(meta()).unwrap();
+        engine.tick().await.unwrap(); // cuts + transcribes two segments now
+        // Already persisted as done before finalize (streaming timing).
+        let mid = store.get_session(1).await.unwrap().unwrap();
+        assert_eq!(mid.segments.len(), 2);
+        assert!(mid.segments.iter().all(|s| s.status == "done"));
+
+        engine.finalize().await.unwrap();
+        let detail = store.get_session(1).await.unwrap().unwrap();
+        assert_eq!(detail.session.status, "archived");
+        assert_eq!(detail.session.full_text.matches("seg-").count(), 2);
+    }
+
+    // Acceptance: exporting a whole meeting transcript yields the full body.
+    #[tokio::test]
+    async fn export_whole_meeting_to_markdown_and_text() {
+        let (store, _dir) = file_store("export");
+        let audio = VecAudio(vec![chunk(5), chunk(5)].into());
+        let mut engine = MeetingEngine::new(
+            audio,
+            FakeTranscriber { streaming: false },
+            store.clone(),
+            NullEvents,
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+        engine.start(meta()).unwrap();
+        engine.tick().await.unwrap();
+        engine.finalize().await.unwrap();
+
+        let detail = store.get_session(1).await.unwrap().unwrap();
+        let md = render_markdown(&detail);
+        let txt = render_plain_text(&detail);
+        assert!(md.contains("# Meeting 1") && md.contains("seg-"));
+        assert!(txt.contains("seg-"));
+        // Plain text body equals the merged full text.
+        assert_eq!(txt, detail.session.full_text);
+    }
+
+    // Acceptance: the existing instant-dictation history table is unaffected by
+    // a full meeting lifecycle on the same db file.
+    #[tokio::test]
+    async fn instant_history_unaffected_by_meeting_writes() {
+        let dir = TempDb::new("history-unaffected");
+        let db = dir.path.clone();
+        let history = crate::storage::HistoryStore::new(db.clone()).unwrap();
+        history
+            .add(crate::storage::HistoryEntry {
+                id: 0,
+                created_at: "2026-06-24T09:00:00".to_string(),
+                app_name: "Notes".to_string(),
+                app_type: "editor".to_string(),
+                raw_text: "instant text".to_string(),
+                polished_text: "instant text".to_string(),
+                language: None,
+                duration_ms: Some(1200),
+            })
+            .await
+            .unwrap();
+
+        // Full meeting lifecycle on the same file.
+        let store = MeetingDbStore::new(db.clone()).unwrap();
+        let audio = VecAudio(vec![chunk(5)].into());
+        let mut engine = MeetingEngine::new(
+            audio,
+            FakeTranscriber { streaming: false },
+            store.clone(),
+            NullEvents,
+            cfg(),
+            PCM_SAMPLE_RATE,
+        );
+        engine.start(meta()).unwrap();
+        engine.tick().await.unwrap();
+        engine.finalize().await.unwrap();
+        let _ = engine.state(); // settle
+
+        // The instant history row is still there, untouched.
+        let entries = history.list(10, 0).await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].raw_text, "instant text");
+        // And the meeting landed in its own table.
+        assert!(store.get_session(1).await.unwrap().is_some());
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1,3 +1,5 @@
+pub mod meeting;
+
 use anyhow::Result;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/stt/whisper_compat.rs
+++ b/src-tauri/src/stt/whisper_compat.rs
@@ -5,7 +5,7 @@ use crate::error::AppError;
 use super::{SttConfig, SttProvider, TranscriptEvent};
 
 /// Configuration for a Whisper-compatible HTTP file-upload STT provider.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WhisperCompatConfig {
     pub provider_name: String,
     pub endpoint: String,


### PR DESCRIPTION
## Summary

- Real `Transcriber` (`SttTranscriber`) wraps the existing `SttProvider` family: file-upload providers (glm-asr/cloud/whisper) transcribe each segment one-shot at finalize, streaming providers (deepgram/assemblyai) transcribe each segment the moment it is cut — both timings driven off the MEL-75 engine.
- SQLite `MeetingDbStore` over two new tables (`meeting_session` + `meeting_segment`); the instant-dictation `history` table is left untouched.
- `MeetingHandle::start` now builds the real transcriber + store (provider/key/session-token resolution mirrors the instant pipeline) in place of the MEL-75 stubs.
- Query/export Tauri commands for the frontend (MEL-77): `list_meetings`, `get_meeting`, `delete_meeting`, `export_meeting` (md/txt → Downloads).

## Notes

- Real-meeting end-to-end (live audio → archive → export) is the frontend subtask (MEL-77) and needs a live session; this PR is backend + fixture/mock self-test. `cargo test` green (140), incl. four e2e tests over the real engine+store: file-based one-shot, streaming per-interval, whole-meeting export, and instant-history-unaffected.
- Frontend unlock — command signatures: `list_meetings(limit,offset)`, `get_meeting(session_id)`, `delete_meeting(session_id)`, `export_meeting(session_id, format?)`.