### PR TITLE
fix: include AppImage DirIcon

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -93,6 +93,13 @@
       "minimumSystemVersion": "10.15",
       "entitlements": "./Entitlements.plist",
       "infoPlist": "./Info.plist"
+    },
+    "linux": {
+      "appimage": {
+        "files": {
+          "icons/icon.png": ".DirIcon"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- include the app icon as root .DirIcon in Linux AppImage bundles
- unblock AppImageHub lint for future release assets

## Verification
- node JSON/config check: AppImage .DirIcon mapping present
- npx tauri info: exited 0 and read project config

## Notes
- Full AppImageHub verification requires a new Linux release asset built on GitHub Actions, then updating https://github.com/AppImage/appimage.github.io/pull/3782 to the new URL/SHA256.