### PR TITLE
fix: make long GLM-ASR dictation recoverable and resilient

### DIFF
--- a/src-tauri/src/output/clipboard.rs
+++ b/src-tauri/src/output/clipboard.rs
@@ -56,13 +56,19 @@ impl TextOutput for ClipboardOutput {
                         "-e",
                         r#"tell application "System Events" to keystroke "v" using command down"#,
                     ])
-                    .status()
-                    .map_err(|e| AppError::Output(format!("osascript error: {}", e)))?;
-                if !status.success() {
-                    return Err(AppError::Output(format!(
-                        "osascript paste failed with exit code: {:?}",
-                        status.code()
-                    )));
+                    .status();
+
+                match status {
+                    Ok(status) if status.success() => {}
+                    Ok(status) => {
+                        tracing::warn!(
+                            "Auto-paste failed with exit code {:?}; text remains copied",
+                            status.code()
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("Auto-paste failed: {}; text remains copied", e);
+                    }
                 }
             }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -121,7 +121,7 @@ const CLIPBOARD_COPY_SETTLE_MS: u64 = 100;
 /// Interval for polling audio volume during recording.
 const VOLUME_POLL_INTERVAL_MS: u64 = 50;
 /// Timeout for STT finalization after recording stops.
-const STT_FINALIZE_TIMEOUT_SECS: u64 = 120;
+const STT_FINALIZE_TIMEOUT_SECS: u64 = 420;
 
 fn generate_cloud_operation_id() -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -827,7 +827,20 @@ impl PipelineHandle {
                     chunk = audio_rx.recv() => {
                         match chunk {
                             Some(data) => {
-                                let _ = provider.send_audio(&data).await;
+                                if let Err(e) = provider.send_audio(&data).await {
+                                    tracing::error!("STT send audio error: {}", e);
+                                    if should_finalize_stt_task(
+                                        abort_flag_ref.as_ref(),
+                                        active_session_id_ref.as_ref(),
+                                        stt_control.id,
+                                    ) {
+                                        let user_error = e.to_user_error();
+                                        *stt_error_ref.lock().unwrap_or_else(|e| e.into_inner()) =
+                                            Some((stt_control.id, user_error.clone()));
+                                        let _ = app_handle.emit("pipeline:error", user_error);
+                                    }
+                                    break;
+                                }
                             }
                             None => {
                                 // Audio channel closed — disconnect and capture final transcript
@@ -1358,13 +1371,18 @@ impl PipelineHandle {
             OutputMode::Clipboard
         };
 
-        if mode == OutputMode::Keyboard && !is_accessibility_trusted() {
-            anyhow::bail!("ACCESSIBILITY_REQUIRED");
-        }
-
         // Linux: check keyboard availability before attempting
         let effective_mode = if mode == OutputMode::Keyboard {
-            if let Err(reason) = output::keyboard::check_keyboard_available() {
+            if !is_accessibility_trusted() {
+                tracing::warn!("Accessibility permission missing, falling back to clipboard");
+                let ue = crate::error::UserError {
+                    code: "output_fallback_clipboard".to_string(),
+                    details: None,
+                    retry_count: 0,
+                };
+                let _ = self.app_handle.emit("pipeline:warning", &ue);
+                OutputMode::Clipboard
+            } else if let Err(reason) = output::keyboard::check_keyboard_available() {
                 if reason == "wayland_unsupported" {
                     tracing::warn!(
                         "Keyboard output not supported on Wayland, falling back to clipboard"

--- a/src-tauri/src/stt/config.rs
+++ b/src-tauri/src/stt/config.rs
@@ -19,6 +19,7 @@ pub struct SttProviderConfig {
     pub endpoint: &'static str,
     pub model: &'static str,
     pub extra_fields: &'static [(&'static str, &'static str)],
+    pub max_request_duration_secs: Option<f64>,
 }
 
 /// Returns the endpoint, model name, and any extra form fields for a given
@@ -29,21 +30,25 @@ pub fn get_whisper_config(provider: &str) -> Option<SttProviderConfig> {
             endpoint: "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions",
             model: "glm-asr-2512",
             extra_fields: &[("stream", "false")],
+            max_request_duration_secs: Some(super::whisper_compat::GLM_ASR_SAFE_CHUNK_SECS),
         }),
         "openai-whisper" => Some(SttProviderConfig {
             endpoint: "https://api.openai.com/v1/audio/transcriptions",
             model: "whisper-1",
             extra_fields: &[],
+            max_request_duration_secs: None,
         }),
         "groq-whisper" => Some(SttProviderConfig {
             endpoint: "https://api.groq.com/openai/v1/audio/transcriptions",
             model: "whisper-large-v3-turbo",
             extra_fields: &[],
+            max_request_duration_secs: None,
         }),
         "siliconflow" => Some(SttProviderConfig {
             endpoint: "https://api.siliconflow.cn/v1/audio/transcriptions",
             model: "FunAudioLLM/SenseVoiceSmall",
             extra_fields: &[],
+            max_request_duration_secs: None,
         }),
         _ => None,
     }
@@ -83,6 +88,7 @@ pub fn build_custom_whisper_config(
         model: model.to_string(),
         extra_fields: vec![],
         api_key_required: false,
+        max_request_duration_secs: None,
     })
 }
 
@@ -98,6 +104,7 @@ pub fn build_known_whisper_config(provider: &str) -> Option<WhisperCompatConfig>
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect(),
         api_key_required: true,
+        max_request_duration_secs: cfg.max_request_duration_secs,
     })
 }
 

--- a/src-tauri/src/stt/whisper_compat.rs
+++ b/src-tauri/src/stt/whisper_compat.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::path::PathBuf;
 
 use crate::error::AppError;
 
@@ -14,11 +15,19 @@ pub struct WhisperCompatConfig {
     pub extra_fields: Vec<(String, String)>,
     /// Local OpenAI-compatible servers often do not require authentication.
     pub api_key_required: bool,
+    /// Some providers cap each transcription request by duration.
+    /// When set, PCM audio is uploaded as multiple WAV chunks.
+    pub max_request_duration_secs: Option<f64>,
 }
 
 /// Max audio buffer: ~24 MB PCM ≈ 12.5 min at 16kHz 16-bit mono.
 /// Keeps the resulting WAV under 25 MB (OpenAI/Groq limit).
 const MAX_AUDIO_BYTES: usize = 24 * 1024 * 1024;
+const MIN_TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
+const MAX_TRANSCRIPTION_TIMEOUT_SECS: u64 = 300;
+const LONG_AUDIO_RETRY_THRESHOLD_SECS: f64 = 60.0;
+const RECORDINGS_TO_KEEP: usize = 10;
+pub(crate) const GLM_ASR_SAFE_CHUNK_SECS: f64 = 28.0;
 
 /// Generic provider for any OpenAI Whisper-compatible transcription API.
 /// Works with: OpenAI, Groq, SiliconFlow, GLM-ASR.
@@ -74,70 +83,124 @@ impl WhisperCompatProvider {
         wav.extend_from_slice(pcm);
         wav
     }
-}
 
-#[async_trait]
-impl SttProvider for WhisperCompatProvider {
-    async fn connect(&mut self, config: &SttConfig) -> Result<(), AppError> {
-        if self.provider_config.api_key_required && config.api_key.is_empty() {
-            return Err(AppError::Auth(format!(
-                "{} API key is empty",
-                self.provider_config.provider_name
-            )));
-        }
-        self.stt_config = Some(config.clone());
-        self.audio_buffer.clear();
-        tracing::info!(
-            "{} provider ready (buffering mode)",
-            self.provider_config.provider_name
+    fn transcription_timeout(audio_len_secs: f64) -> std::time::Duration {
+        let secs = (audio_len_secs.ceil() as u64 + 60).clamp(
+            MIN_TRANSCRIPTION_TIMEOUT_SECS,
+            MAX_TRANSCRIPTION_TIMEOUT_SECS,
         );
-        Ok(())
+        std::time::Duration::from_secs(secs)
     }
 
-    async fn send_audio(&mut self, chunk: &[u8]) -> Result<(), AppError> {
-        if self.audio_buffer.len() + chunk.len() > MAX_AUDIO_BYTES {
-            return Err(AppError::Config(format!(
-                "{}: audio exceeds maximum length (~12 min)",
-                self.provider_config.provider_name
-            )));
+    fn recordings_dir() -> Option<PathBuf> {
+        #[cfg(target_os = "macos")]
+        {
+            std::env::var_os("HOME").map(|home| {
+                PathBuf::from(home)
+                    .join("Library")
+                    .join("Application Support")
+                    .join("com.opentypeless.app")
+                    .join("recordings")
+            })
         }
-        self.audio_buffer.extend_from_slice(chunk);
-        Ok(())
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            None
+        }
     }
 
-    async fn recv_transcript(&mut self) -> Result<Option<TranscriptEvent>, AppError> {
-        // File-based providers transcribe in disconnect(); keep this future
-        // pending so the pipeline select loop does not busy-spin while recording.
-        std::future::pending().await
-    }
-
-    async fn disconnect(&mut self) -> Result<Option<String>, AppError> {
-        let config = match &self.stt_config {
-            Some(c) => c.clone(),
-            None => return Ok(None),
+    fn save_wav_snapshot(provider_name: &str, wav_data: &[u8], audio_len_secs: f64) {
+        let Some(dir) = Self::recordings_dir() else {
+            return;
         };
 
-        if self.audio_buffer.is_empty() {
-            tracing::info!(
-                "{}: no audio buffered, skipping",
-                self.provider_config.provider_name
-            );
-            return Ok(None);
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            tracing::warn!("Failed to create recordings dir {:?}: {}", dir, e);
+            return;
         }
 
-        let audio_len_secs = self.audio_buffer.len() as f64 / (config.sample_rate as f64 * 2.0);
-        let wav_data = Self::build_wav(&self.audio_buffer, config.sample_rate);
-        self.audio_buffer.clear();
-        tracing::info!(
-            "{}: sending {:.1}s of audio for transcription",
-            self.provider_config.provider_name,
-            audio_len_secs
-        );
+        let safe_provider = provider_name.replace(|c: char| !c.is_ascii_alphanumeric(), "_");
+        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+        let path = dir.join(format!("{}_{}.wav", timestamp, safe_provider));
+        let latest_path = dir.join("latest.wav");
 
+        match std::fs::write(&path, wav_data) {
+            Ok(()) => {
+                let _ = std::fs::write(&latest_path, wav_data);
+                let _ = std::fs::write(
+                    dir.join("latest.json"),
+                    serde_json::json!({
+                        "path": path,
+                        "provider": provider_name,
+                        "duration_seconds": audio_len_secs,
+                        "created_at": chrono::Local::now().to_rfc3339(),
+                    })
+                    .to_string(),
+                );
+                tracing::info!("Saved transcription audio snapshot to {:?}", latest_path);
+                Self::prune_recordings(&dir);
+            }
+            Err(e) => tracing::warn!("Failed to save transcription audio snapshot: {}", e),
+        }
+    }
+
+    fn prune_recordings(dir: &PathBuf) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+
+        let mut wavs: Vec<_> = entries
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let path = entry.path();
+                if path.file_name().and_then(|name| name.to_str()) == Some("latest.wav") {
+                    return None;
+                }
+                if path.extension().and_then(|ext| ext.to_str()) != Some("wav") {
+                    return None;
+                }
+                let modified = entry.metadata().ok()?.modified().ok()?;
+                Some((modified, path))
+            })
+            .collect();
+
+        wavs.sort_by_key(|(modified, _)| *modified);
+        while wavs.len() > RECORDINGS_TO_KEEP {
+            if let Some((_, path)) = wavs.first() {
+                let _ = std::fs::remove_file(path);
+            }
+            wavs.remove(0);
+        }
+    }
+
+    fn pcm_chunks<'a>(&self, pcm: &'a [u8], sample_rate: u32) -> Vec<&'a [u8]> {
+        let Some(max_secs) = self.provider_config.max_request_duration_secs else {
+            return vec![pcm];
+        };
+
+        let bytes_per_second = sample_rate as usize * 2;
+        let mut max_chunk_bytes = (bytes_per_second as f64 * max_secs).floor() as usize;
+        max_chunk_bytes -= max_chunk_bytes % 2;
+        if max_chunk_bytes == 0 || pcm.len() <= max_chunk_bytes {
+            return vec![pcm];
+        }
+
+        pcm.chunks(max_chunk_bytes).collect()
+    }
+
+    async fn transcribe_wav(
+        &self,
+        wav_data: &[u8],
+        config: &SttConfig,
+        audio_len_secs: f64,
+        file_name: String,
+    ) -> Result<Option<String>, AppError> {
         let mut attempt = 0u32;
+        let request_timeout = Self::transcription_timeout(audio_len_secs);
         loop {
-            let file_part = reqwest::multipart::Part::bytes(wav_data.clone())
-                .file_name("audio.wav")
+            let file_part = reqwest::multipart::Part::bytes(wav_data.to_vec())
+                .file_name(file_name.clone())
                 .mime_str("audio/wav")
                 .map_err(|e| AppError::Config(e.to_string()))?;
 
@@ -161,7 +224,7 @@ impl SttProvider for WhisperCompatProvider {
                 .client
                 .post(&self.provider_config.endpoint)
                 .multipart(form)
-                .timeout(std::time::Duration::from_secs(60));
+                .timeout(request_timeout);
 
             if !config.api_key.trim().is_empty() {
                 request = request.header("Authorization", format!("Bearer {}", config.api_key));
@@ -227,7 +290,11 @@ impl SttProvider for WhisperCompatProvider {
                         });
                     }
                 }
-                Err(e) if e.is_timeout() && attempt < 2 => {
+                Err(e)
+                    if e.is_timeout()
+                        && audio_len_secs <= LONG_AUDIO_RETRY_THRESHOLD_SECS
+                        && attempt < 2 =>
+                {
                     tracing::warn!(
                         "{} timeout (attempt {}/3)",
                         self.provider_config.provider_name,
@@ -243,6 +310,101 @@ impl SttProvider for WhisperCompatProvider {
                 Err(e) => return Err(e.into()),
             }
         }
+    }
+}
+
+#[async_trait]
+impl SttProvider for WhisperCompatProvider {
+    async fn connect(&mut self, config: &SttConfig) -> Result<(), AppError> {
+        if self.provider_config.api_key_required && config.api_key.is_empty() {
+            return Err(AppError::Auth(format!(
+                "{} API key is empty",
+                self.provider_config.provider_name
+            )));
+        }
+        self.stt_config = Some(config.clone());
+        self.audio_buffer.clear();
+        tracing::info!(
+            "{} provider ready (buffering mode)",
+            self.provider_config.provider_name
+        );
+        Ok(())
+    }
+
+    async fn send_audio(&mut self, chunk: &[u8]) -> Result<(), AppError> {
+        if self.audio_buffer.len() + chunk.len() > MAX_AUDIO_BYTES {
+            return Err(AppError::Config(format!(
+                "{}: audio exceeds maximum length (~12 min)",
+                self.provider_config.provider_name
+            )));
+        }
+        self.audio_buffer.extend_from_slice(chunk);
+        Ok(())
+    }
+
+    async fn recv_transcript(&mut self) -> Result<Option<TranscriptEvent>, AppError> {
+        // File-based providers transcribe in disconnect(); keep this future
+        // pending so the pipeline select loop does not busy-spin while recording.
+        std::future::pending().await
+    }
+
+    async fn disconnect(&mut self) -> Result<Option<String>, AppError> {
+        let config = match &self.stt_config {
+            Some(c) => c.clone(),
+            None => return Ok(None),
+        };
+
+        if self.audio_buffer.is_empty() {
+            tracing::info!(
+                "{}: no audio buffered, skipping",
+                self.provider_config.provider_name
+            );
+            return Ok(None);
+        }
+
+        let pcm_data = std::mem::take(&mut self.audio_buffer);
+        let audio_len_secs = pcm_data.len() as f64 / (config.sample_rate as f64 * 2.0);
+        let wav_data = Self::build_wav(&pcm_data, config.sample_rate);
+        Self::save_wav_snapshot(
+            &self.provider_config.provider_name,
+            &wav_data,
+            audio_len_secs,
+        );
+        tracing::info!(
+            "{}: sending {:.1}s of audio for transcription",
+            self.provider_config.provider_name,
+            audio_len_secs
+        );
+
+        let chunks = self.pcm_chunks(&pcm_data, config.sample_rate);
+        if chunks.len() > 1 {
+            tracing::info!(
+                "{}: splitting {:.1}s audio into {} chunks",
+                self.provider_config.provider_name,
+                audio_len_secs,
+                chunks.len()
+            );
+        }
+
+        let mut texts = Vec::new();
+        for (idx, chunk) in chunks.iter().enumerate() {
+            let chunk_len_secs = chunk.len() as f64 / (config.sample_rate as f64 * 2.0);
+            let chunk_wav = Self::build_wav(chunk, config.sample_rate);
+            if let Some(text) = self
+                .transcribe_wav(
+                    &chunk_wav,
+                    &config,
+                    chunk_len_secs,
+                    format!("audio_part_{}.wav", idx + 1),
+                )
+                .await?
+            {
+                texts.push(text);
+            }
+        }
+
+        let text = texts.join(" ").trim().to_string();
+        Ok(if text.is_empty() { None } else { Some(text) })
     }
 
     fn name(&self) -> &str {
@@ -262,6 +424,7 @@ mod tests {
             model: "test-model".to_string(),
             extra_fields: vec![],
             api_key_required: false,
+            max_request_duration_secs: None,
         });
 
         let result = provider
@@ -286,6 +449,7 @@ mod tests {
             model: "test-model".to_string(),
             extra_fields: vec![],
             api_key_required: true,
+            max_request_duration_secs: None,
         });
 
         let result = tokio::time::timeout(

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -37,7 +37,7 @@
     "stt_failed": "语音识别失败。{{details}}",
     "stt_quota_exceeded": "云端语音识别额度已用完。请升级到 Pro 或切换到 BYOK 模式。",
     "stt_no_speech_detected": "未检测到语音，请重试。",
-    "output_fallback_clipboard": "文本输出失败，结果已改为复制到剪贴板。{{details}}",
+    "output_fallback_clipboard": "已复制到剪贴板，可手动粘贴。{{details}}",
     "output_wayland_unsupported": "Wayland 暂不支持键盘输出，结果已改为复制到剪贴板。",
     "llm_failed": "AI 润色失败，已改为输出原始文本。{{details}}",
     "llm_quota_exceeded": "云端 AI 额度已用完。请升级到 Pro 或切换到 BYOK 模式。",


### PR DESCRIPTION
## Summary

This PR improves long-form dictation reliability for GLM-ASR and makes failed transcription attempts recoverable.

## Changes

- Preserve a local WAV snapshot before transcription so users do not lose recordings when STT fails.
- Store recent recordings under the app support directory with `latest.wav` / `latest.json` helpers for recovery.
- Add provider-level request duration limits and split GLM-ASR audio into safe chunks before upload.
- Stitch chunked GLM-ASR results back into a single transcript.
- Increase the STT finalization timeout for longer dictation sessions.
- Use an audio-length-aware HTTP timeout instead of a fixed short timeout.
- Surface audio send failures instead of silently ignoring them.
- Improve macOS output fallback by copying text to clipboard when direct keyboard output is unavailable.

## Why

GLM-ASR rejects audio longer than its provider-side request duration limit. Before this change, longer dictation could fail after recording, and the original audio was not retained for retry or recovery.

With this PR, long dictation is split into provider-safe requests, and the original recording is preserved locally before transcription starts.

## Validation

- `cargo test`
- `npm test`
- Manually verified the GLM-ASR provider duration limit and confirmed shorter chunked requests can be transcribed successfully.

## Privacy

Recorded audio is saved only to the user's local app support directory for recovery. This PR does not add telemetry or upload recordings anywhere other than the configured STT provider request path.
