### PR TITLE
ci: require signed Windows releases

### DIFF
--- a/.github/scripts/import-windows-certificate.ps1
+++ b/.github/scripts/import-windows-certificate.ps1
@@ -4,8 +4,7 @@ $hasCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)
 $hasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
 
 if (-not $hasCertificate -and -not $hasPassword) {
-  Write-Host "Windows signing certificate not configured; building unsigned Windows artifacts."
-  exit 0
+  Write-Error "Windows signing certificate is required. Configure WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD, or publish Windows through the Release Windows SignPath workflow."
 }
 
 if (-not $hasCertificate -or -not $hasPassword) {

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -32,14 +32,17 @@ Linux:
 - `LINUX_GPG_KEY_ID`: GPG key ID or fingerprint
 - `LINUX_GPG_PASSPHRASE`: GPG key passphrase
 
-Windows:
+Windows PFX fallback:
 
-- `WINDOWS_CERTIFICATE`: optional base64-encoded PFX code signing certificate
+- `WINDOWS_CERTIFICATE`: base64-encoded PFX code signing certificate
 - `WINDOWS_CERTIFICATE_PASSWORD`: required when `WINDOWS_CERTIFICATE` is set
 - `WINDOWS_TIMESTAMP_URL`: optional timestamp server URL; defaults to DigiCert
 
-The release workflow publishes Windows artifacts even when Windows signing
-secrets are not configured. In that case, the Windows installers are unsigned.
+The general `Release` workflow refuses to build or publish Windows artifacts
+when the PFX signing secrets are absent. Use that workflow for Windows only when
+a trusted PFX certificate is configured. Otherwise, publish Windows through the
+dedicated `Release Windows SignPath` workflow below. Unsigned and test-signed
+installers must never be attached to a public release.
 
 Windows SignPath:
 
@@ -63,6 +66,12 @@ Signing policies whose slug starts with `test-` or `test_` are dry-run only.
 They may verify the build-to-SignPath integration, but the workflow refuses to
 publish those installers to a production GitHub Release. Publishing requires a
 production SignPath policy whose Authenticode result is `Valid`.
+
+For a complete release without a PFX certificate, dispatch the general
+`Release` workflow separately for `macos` and `linux`, then dispatch
+`Release Windows SignPath` with `publish_release` set to `true`. Do not use the
+general workflow's `all` option until a trusted Windows PFX certificate is
+configured, because its Windows job will intentionally fail closed.
 
 ## Windows Certificate Notes
 


### PR DESCRIPTION
## Summary

- fail the general Windows release job when no trusted PFX certificate is configured
- direct certificate-less production releases to the guarded SignPath workflow
- document the signed macOS, Linux, and Windows release sequence

This prevents unsigned or test-signed Windows installers from reaching a public release.

## Validation

The executable change passed the complete frontend, audit, Linux, macOS, Windows, CodeQL, and Typos matrix in the CI fork: https://github.com/toverwu-qaq/opentypeless/actions/runs/29262911752

Owner-repo Actions are currently unable to start because GitHub reports an account billing lock.
