### PR TITLE
ci: allow explicit unsigned Windows releases

### DIFF
--- a/.github/scripts/import-windows-certificate.ps1
+++ b/.github/scripts/import-windows-certificate.ps1
@@ -2,8 +2,13 @@ $ErrorActionPreference = "Stop"
 
 $hasCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)
 $hasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
+$allowUnsigned = $env:ALLOW_UNSIGNED_WINDOWS -eq 'true'
 
 if (-not $hasCertificate -and -not $hasPassword) {
+  if ($allowUnsigned) {
+    Write-Warning "Unsigned Windows release explicitly allowed for this manual dispatch."
+    exit 0
+  }
   Write-Error "Windows signing certificate is required. Configure WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD, or publish Windows through the Release Windows SignPath workflow."
 }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,14 @@ on:
         options:
           - 'false'
           - 'true'
+      allow_unsigned_windows:
+        description: 'Windows only: explicitly allow publishing unsigned installers'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 permissions:
   contents: write
@@ -162,6 +170,7 @@ jobs:
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
           WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL }}
+          ALLOW_UNSIGNED_WINDOWS: ${{ github.event.inputs.allow_unsigned_windows }}
         run: ./.github/scripts/import-windows-certificate.ps1
 
       - uses: tauri-apps/tauri-action@v0
@@ -184,7 +193,7 @@ jobs:
         with:
           owner: tover0314-w
           repo: opentypeless
-          releaseCommitish: ${{ github.sha }}
+          releaseCommitish: main
           tagName: ${{ github.event.inputs.tag || github.ref_name }}
           releaseName: 'OpenTypeless ${{ github.event.inputs.tag || github.ref_name }}'
           releaseBody: 'See the assets below to download and install.'

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -42,7 +42,12 @@ The general `Release` workflow refuses to build or publish Windows artifacts
 when the PFX signing secrets are absent. Use that workflow for Windows only when
 a trusted PFX certificate is configured. Otherwise, publish Windows through the
 dedicated `Release Windows SignPath` workflow below. Unsigned and test-signed
-installers must never be attached to a public release.
+installers are blocked from public releases by default.
+
+For a deliberate temporary exception, a manual workflow dispatch may set
+`allow_unsigned_windows` to `true`. This opt-in is disabled by default and is
+the only path that permits the general workflow to publish unsigned Windows
+installers. Tag-triggered and ordinary manual releases still fail closed.
 
 Windows SignPath:
 

--- a/src/lib/__tests__/releaseVersion.test.ts
+++ b/src/lib/__tests__/releaseVersion.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import constantsSource from '../constants.ts?raw'
+import windowsCertificateScriptSource from '../../../.github/scripts/import-windows-certificate.ps1?raw'
 import releaseWorkflowSource from '../../../.github/workflows/release.yml?raw'
 
 describe('release version wiring', () => {
@@ -9,5 +10,23 @@ describe('release version wiring', () => {
 
   it('exports VITE_APP_VERSION during the GitHub release build', () => {
     expect(releaseWorkflowSource).toContain('VITE_APP_VERSION=v$VERSION')
+  })
+
+  it('creates cross-repository releases from the owner main branch', () => {
+    expect(releaseWorkflowSource).toContain('releaseCommitish: main')
+    expect(releaseWorkflowSource).not.toContain('releaseCommitish: ${{ github.sha }}')
+  })
+
+  it('requires an explicit opt-in before publishing unsigned Windows installers', () => {
+    expect(releaseWorkflowSource).toContain('allow_unsigned_windows:')
+    expect(releaseWorkflowSource).toContain(
+      'ALLOW_UNSIGNED_WINDOWS: ${{ github.event.inputs.allow_unsigned_windows }}',
+    )
+    expect(windowsCertificateScriptSource).toContain(
+      "$allowUnsigned = $env:ALLOW_UNSIGNED_WINDOWS -eq 'true'",
+    )
+    expect(windowsCertificateScriptSource).toContain(
+      'Unsigned Windows release explicitly allowed for this manual dispatch.',
+    )
   })
 })


### PR DESCRIPTION
## Summary

- add a default-off manual opt-in for unsigned Windows release artifacts
- keep tag-triggered and ordinary manual releases fail-closed
- point cross-repository release creation at the owner repository's main branch
- cover both release invariants with tests

## Validation

The exact change passed frontend, audit, Linux, macOS, Windows, CodeQL, and Typos in the CI fork:
https://github.com/toverwu-qaq/opentypeless/actions/runs/29264627310

Local validation:
- \`npm run build\`
- \`npm run lint\`
- \`npm run format:check\`
- \`npm test\` (41 files, 375 tests)
