### PR TITLE
feat: add CLI toggle and ask triggers for window managers

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -731,7 +731,40 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            if args.iter().any(|arg| arg == "toggle") {
+                let app_handle = app.clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Some(state) = app_handle.try_state::<pipeline::PipelineHandle>() {
+                        if matches!(state.current_state(), pipeline::PipelineState::Idle) {
+                            let _ = state.start().await;
+                        } else {
+                            let _ = state.stop().await;
+                        }
+                    }
+                });
+                return;
+            }
+            if args.iter().any(|arg| arg == "ask") {
+                let app_handle = app.clone();
+                tauri::async_runtime::spawn(async move {
+                    use tauri::Manager;
+                    let ask_state = app_handle.state::<commands::ask::AskDictationState>();
+                    let config_state = app_handle.state::<storage::ConfigManager>();
+                    let token_store = app_handle.state::<SessionTokenStore>();
+                    let client = app_handle.state::<reqwest::Client>();
+                    let _ = commands::ask::start_ask_flow(
+                        app_handle.clone(),
+                        ask_state,
+                        config_state,
+                        token_store,
+                        client,
+                    )
+                    .await;
+                });
+                return;
+            }
+
             // Deep-link URL forwarding is handled automatically by the
             // "deep-link" feature of single-instance plugin.
             // Just focus the main window so the user sees the result.


### PR DESCRIPTION
## Summary

This PR adds native CLI argument support for  toggle  and  ask , allowing users to programmatically trigger the core voice-recording features from outside the app.

This is incredibly useful for Linux/Wayland users (where Tauri's global hotkey plugin is often restricted by the compositor) because it allows them to bind  opentypeless toggle  and  opentypeless ask  directly to their window manager shortcuts (e.g., in Hyprland, Sway, or Niri) to seamlessly interact with the background instance.

  ## Change Type

  [ ] Bug fix
  [✓] New feature
  [ ] Refactor
  [ ] Documentation
  [ ] CI / Infrastructure

  ## Changes

  • Modified the  tauri_plugin_single_instance  closure in  src-tauri/src/lib.rs  to intercept incoming arguments passed to a secondary instance.
  • Added support for the  toggle  argument, which safely clones the  AppHandle , queries the  PipelineHandle  state asynchronously, and toggles the main dictation recording on/off.
  • Added support for the  ask  argument, which extracts the necessary states from the  AppHandle  to invoke commands::ask::start_ask_flow , properly initializing the backend and surfacing the "Ask Anything" popup.

  ## Test Plan

  [✓] Tested locally on Linux (Wayland)
  [✓]  npm run build  passes
  [✓]  npx vitest run  passes
  [✓]  cargo clippy -- -D warnings  passes
  [✓] No regressions in existing functionality

Example configuration with Niri
```kdl
    binds {
        // Press Mod+Space to start/stop the main voice dictation
        Mod+Space { spawn "opentypeless" "toggle"; }

        // Press Mod+Shift+Space to instantly bring up the AI Ask popup
        Mod+Shift+Space { spawn "opentypeless" "ask"; }
    }
```

  ## Screenshots / Recordings

<img width="2014" height="1288" alt="image" src="https://github.com/user-attachments/assets/be38f258-64d3-4a0c-a71e-5150aaa464c5" />


  ## Related Issues

  **N/A***