### PR TITLE
perf: start audio capture before STT connect to eliminate word loss

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,10 +2,59 @@ fn main() {
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-lib=framework=Speech");
 
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", target_env = "msvc"))]
     println!(
         "cargo:rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
     );
+
+    #[cfg(all(target_os = "windows", target_env = "gnu"))]
+    {
+        // Generate a manifest resource for Common Controls v6 (visual styles)
+        // using windres, since GNU ld does not support /MANIFESTDEPENDENCY.
+        let manifest = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>"#;
+        let out_dir = std::path::PathBuf::from(
+            std::env::var("OUT_DIR").expect("OUT_DIR not set"),
+        );
+        let manifest_path = out_dir.join("app.manifest");
+        let rc_path = out_dir.join("app.rc");
+        let res_path = out_dir.join("app.res");
+        std::fs::write(&manifest_path, manifest).expect("failed to write manifest");
+        // Use forward slashes in the RC file to avoid backslash escape issues
+        let manifest_posix = manifest_path.display().to_string().replace('\\', "/");
+        std::fs::write(
+            &rc_path,
+            format!("1 24 \"{}\"", manifest_posix),
+        )
+        .expect("failed to write rc file");
+        let status = std::process::Command::new("windres")
+            .arg(&rc_path)
+            .arg("-o")
+            .arg(&res_path)
+            .status()
+            .expect("failed to run windres");
+        if status.success() {
+            println!(
+                "cargo:rustc-link-arg-bin=opentypeless={}",
+                res_path.display()
+            );
+        } else {
+            panic!("windres failed (status: {})", status);
+        }
+    }
 
     tauri_build::build()
 }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -41,7 +41,7 @@ pub struct AudioCaptureHandle {
 impl AudioCaptureHandle {
     /// Start audio capture on a dedicated thread. Returns a handle and a receiver for audio chunks.
     pub fn start(config: AudioConfig) -> Result<(Self, mpsc::Receiver<Vec<u8>>)> {
-        let (audio_tx, audio_rx) = mpsc::channel::<Vec<u8>>(200);
+        let (audio_tx, audio_rx) = mpsc::channel::<Vec<u8>>(1200); // ~24s buffer at 20ms/chunk
         let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
         let volume = Arc::new(Mutex::new(0.0f32));
         let state = Arc::new(Mutex::new(CaptureState::Recording));

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1221,7 +1221,7 @@ impl PipelineHandle {
                 None
             };
 
-        // P0-3: Pre-connect STT provider before spawning task
+        // P0-3: Start audio capture first so it buffers while STT connects.
         let cloud_operation_id = generate_cloud_operation_id();
         *self
             .cloud_operation_id
@@ -1246,63 +1246,8 @@ impl PipelineHandle {
             operation_id: Some(cloud_operation_id),
         };
 
-        let mut provider = match stt::create_provider(
-            &config_data.stt_provider,
-            custom_whisper_config,
-            Some(self.shared_client.clone()),
-        ) {
-            Ok(provider) => provider,
-            Err(e) => {
-                tracing::error!("STT provider creation failed: {}", e);
-                let _ = self
-                    .app_handle
-                    .emit("pipeline:error", format!("STT configuration failed: {e}"));
-                *self
-                    .preloaded_config
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner()) = None;
-                *self
-                    .preloaded_app_ctx
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner()) = None;
-                *self
-                    .preloaded_dictionary
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner()) = None;
-                *self
-                    .preloaded_correction_rules
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner()) = None;
-                self.set_state(PipelineState::Idle);
-                return Ok(());
-            }
-        };
-        if let Err(e) = provider.connect(&stt_config).await {
-            tracing::error!("STT connect failed: {}", e);
-            let _ = self
-                .app_handle
-                .emit("pipeline:error", format!("STT connection failed: {e}"));
-            *self
-                .preloaded_config
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()) = None;
-            *self
-                .preloaded_app_ctx
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()) = None;
-            *self
-                .preloaded_dictionary
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()) = None;
-            *self
-                .preloaded_correction_rules
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()) = None;
-            self.set_state(PipelineState::Idle);
-            return Ok(());
-        }
-
-        // Start audio capture on dedicated thread
+        // Start audio capture FIRST so audio buffers in the channel while
+        // STT provider connects. This prevents word loss during startup.
         let config = AudioConfig::default();
         let (handle, mut audio_rx) = match AudioCaptureHandle::start(config) {
             Ok(result) => result,
@@ -1332,9 +1277,8 @@ impl PipelineHandle {
             }
         };
 
-        // Store the audio handle's volume reference.
-        // Check abort_flag first — if abort() was called while we were connecting
-        // to STT, don't store the handle (it would be orphaned with nobody to stop it).
+        // Check abort_flag — if abort() was called during config loading,
+        // drop the handle immediately (stops the capture thread).
         if self.abort_flag.load(Ordering::SeqCst) {
             tracing::info!("Pipeline aborted during setup, discarding audio capture");
             // handle drops here, stopping the capture thread
@@ -1399,10 +1343,12 @@ impl PipelineHandle {
             .unwrap_or_else(|error| error.into_inner()) = options
             .force_translate
             .then(|| TranslationOperationState::new(config_data.translation.active_target.clone()));
+        // Set Recording state early — audio is already flowing, so the capsule
+        // can show recording immediately while STT provider connects.
         self.set_state(PipelineState::Recording);
         let _ = self.app_handle.emit("pipeline:voice_mode", voice_mode);
 
-        // Volume monitoring task
+        // Volume monitoring task (audio is already being captured)
         let app_handle = self.app_handle.clone();
         let audio_handle_ref = self.audio_handle.clone();
         let state_ref = self.state.clone();
@@ -1422,6 +1368,79 @@ impl PipelineHandle {
                 let _ = app_handle.emit("audio:volume", vol);
             }
         });
+
+        // Create + connect STT provider (audio is buffering in the channel)
+        let mut provider = match stt::create_provider(
+            &config_data.stt_provider,
+            custom_whisper_config,
+            Some(self.shared_client.clone()),
+        ) {
+            Ok(provider) => provider,
+            Err(e) => {
+                tracing::error!("STT provider creation failed: {}", e);
+                // Stop audio capture that was started earlier
+                {
+                    let mut handle = self.audio_handle.lock().unwrap_or_else(|e| e.into_inner());
+                    if let Some(ref mut h) = *handle {
+                        h.stop();
+                    }
+                    *handle = None;
+                }
+                let _ = self
+                    .app_handle
+                    .emit("pipeline:error", format!("STT configuration failed: {e}"));
+                *self
+                    .preloaded_config
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+                *self
+                    .preloaded_app_ctx
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+                *self
+                    .preloaded_dictionary
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+                *self
+                    .preloaded_correction_rules
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+                self.set_state(PipelineState::Idle);
+                return Ok(());
+            }
+        };
+        if let Err(e) = provider.connect(&stt_config).await {
+            tracing::error!("STT connect failed: {}", e);
+            // Stop audio capture that was started earlier
+            {
+                let mut handle = self.audio_handle.lock().unwrap_or_else(|e| e.into_inner());
+                if let Some(ref mut h) = *handle {
+                    h.stop();
+                }
+                *handle = None;
+            }
+            let _ = self
+                .app_handle
+                .emit("pipeline:error", format!("STT connection failed: {e}"));
+            *self
+                .preloaded_config
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = None;
+            *self
+                .preloaded_app_ctx
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = None;
+            *self
+                .preloaded_dictionary
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = None;
+            *self
+                .preloaded_correction_rules
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = None;
+            self.set_state(PipelineState::Idle);
+            return Ok(());
+        }
 
         // Selected text will be captured in stop() after hotkey is released,
         // so Ctrl+C simulation won't conflict with held keys.
@@ -1591,7 +1610,7 @@ impl PipelineHandle {
 
     pub async fn stop(&self) -> Result<()> {
         // Acquire pipeline_lock so we wait for start() to finish its setup
-        // (load_config, connect STT, start audio) before reading shared state.
+        // (load_config, start audio, connect STT) before reading shared state.
         // Released before the long stt_done wait so start() isn't blocked 120s.
         let guard = self.pipeline_lock.lock().await;
 


### PR DESCRIPTION
Reorder start_with_options() so audio capture begins immediately and Recording state is emitted early, while STT provider connects in the background. Audio buffers in the enlarged mpsc channel (200→1200 slots) during connection setup, preventing word loss when users speak right after pressing the hotkey.

Also fixes build.rs to support GNU toolchain on Windows via windres.

## Summary

<!-- What does this PR do and why? -->

## Change Type

- [*] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

Closes #83 
