### PR TITLE
fix: native select color scheme

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -58,6 +58,14 @@
 }
 
 /* Base styles */
+html {
+  color-scheme: light;
+}
+
+html.dark {
+  color-scheme: dark;
+}
+
 html,
 body,
 #root {


### PR DESCRIPTION
## Summary

On Linux, when the OS color scheme is dark, select components in OpenTypeless are rendered with light background & text, making them difficult to read.

This PR adds the CSS `color-scheme` property to the `html` element, so the browser can render them correctly.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Changes

- Add `color-scheme` declarations to the `html` element for both light and dark themes.

## Test Plan

- [x] Tested locally on Linux (Manjaro)
- [x] `npm run build` passes
- [x] `npx vitest run` passes
- [ ] `cargo clippy -- -D warnings` passes (Not applicable)
- [x] No regressions in existing functionality

## Screenshots / Recordings

<img width="2560" height="1334" alt="Before" src="https://github.com/user-attachments/assets/fb74ba6b-33d8-4d34-b260-b84cab692211" />

<img width="2559" height="1335" alt="After" src="https://github.com/user-attachments/assets/cdfbe6dc-3a3a-4cce-861b-552384affa85" />

## Related Issues

Not applicable.