### PR TITLE
fix: align AssemblyAI streaming frames

### DIFF
--- a/src-tauri/src/stt/assemblyai.rs
+++ b/src-tauri/src/stt/assemblyai.rs
@@ -16,12 +16,14 @@ const MIN_CHUNK_MS: u32 = 50;
 const TARGET_CHUNK_MS: u32 = 100;
 const MAX_CHUNK_MS: u32 = 1000;
 const BYTES_PER_SAMPLE: u32 = 2; // PCM s16le mono
+const SPEECH_MODEL: &str = "universal-3-5-pro";
 const TERMINATION_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct AssemblyAiProvider {
     ws: Option<WsStream>,
     pending: Vec<u8>,
     sample_rate: u32,
+    url_override: Option<String>,
 }
 
 impl Default for AssemblyAiProvider {
@@ -36,16 +38,41 @@ impl AssemblyAiProvider {
             ws: None,
             pending: Vec::new(),
             sample_rate: 16000,
+            url_override: None,
         }
     }
 
-    fn build_url(config: &SttConfig) -> String {
+    #[cfg(test)]
+    fn with_url(url: String) -> Self {
+        Self {
+            url_override: Some(url),
+            ..Self::new()
+        }
+    }
+
+    fn resolved_sample_rate(config: &SttConfig) -> u32 {
+        if config.sample_rate == 0 {
+            16000
+        } else {
+            config.sample_rate
+        }
+    }
+
+    fn build_url(sample_rate: u32) -> String {
         format!(
             "wss://streaming.assemblyai.com/v3/ws?\
              sample_rate={}&\
+             encoding=pcm_s16le&\
+             speech_model={}&\
              format_turns=true",
-            config.sample_rate
+            sample_rate, SPEECH_MODEL
         )
+    }
+
+    fn connection_url(&self, sample_rate: u32) -> String {
+        self.url_override
+            .clone()
+            .unwrap_or_else(|| Self::build_url(sample_rate))
     }
 
     fn bytes_for_ms(&self, ms: u32) -> usize {
@@ -71,19 +98,20 @@ impl AssemblyAiProvider {
 
             // Never send a final undersized frame if we can avoid it; pad only on force
             // when residual audio is shorter than the minimum (end of utterance).
+            let mut frame = self.pending[..take].to_vec();
             if take < min_bytes {
                 if !force {
                     break;
                 }
                 // Pad short residual with silence so AssemblyAI accepts the last frame.
-                let mut frame = self.pending.drain(..).collect::<Vec<u8>>();
                 frame.resize(min_bytes, 0);
                 self.send_frame(&frame).await?;
+                self.pending.drain(..take);
                 break;
             }
 
-            let frame: Vec<u8> = self.pending.drain(..take).collect();
             self.send_frame(&frame).await?;
+            self.pending.drain(..take);
         }
 
         Ok(())
@@ -122,7 +150,7 @@ fn parse_transcript_message(text: &str) -> Result<Option<TranscriptEvent>, AppEr
             let turn_is_formatted = v
                 .get("turn_is_formatted")
                 .and_then(|value| value.as_bool())
-                .unwrap_or(end_of_turn);
+                .unwrap_or(false);
 
             if end_of_turn && turn_is_formatted {
                 Ok(Some(TranscriptEvent::Final {
@@ -160,15 +188,17 @@ fn append_final_text(final_text: &mut String, text: &str) {
     final_text.push_str(trimmed);
 }
 
-async fn read_until_termination(ws: &mut WsStream) -> Result<Option<String>, AppError> {
-    let deadline = tokio::time::Instant::now() + TERMINATION_TIMEOUT;
+async fn read_until_termination_with_timeout(
+    ws: &mut WsStream,
+    timeout: Duration,
+) -> Result<Option<String>, AppError> {
+    let deadline = tokio::time::Instant::now() + timeout;
     let mut final_text = String::new();
 
     loop {
         let now = tokio::time::Instant::now();
         if now >= deadline {
-            tracing::warn!("Timed out waiting for AssemblyAI Termination message");
-            break;
+            return Err(AppError::Timeout(timeout));
         }
 
         let next = tokio::time::timeout(deadline - now, ws.next()).await;
@@ -183,28 +213,29 @@ async fn read_until_termination(ws: &mut WsStream) -> Result<Option<String>, App
                 }
                 _ => {}
             },
-            Ok(Some(Ok(Message::Close(_)))) | Ok(None) => break,
+            Ok(Some(Ok(Message::Close(_))) | None) => {
+                return Err(AppError::Network(
+                    "AssemblyAI WebSocket closed before Termination".to_string(),
+                ));
+            }
             Ok(Some(Err(e))) => return Err(AppError::Network(e.to_string())),
             Ok(Some(Ok(_))) => {}
-            Err(_) => {
-                tracing::warn!("Timed out waiting for AssemblyAI Termination message");
-                break;
-            }
+            Err(_) => return Err(AppError::Timeout(timeout)),
         }
     }
 
     Ok((!final_text.is_empty()).then_some(final_text))
 }
 
+async fn read_until_termination(ws: &mut WsStream) -> Result<Option<String>, AppError> {
+    read_until_termination_with_timeout(ws, TERMINATION_TIMEOUT).await
+}
+
 #[async_trait]
 impl SttProvider for AssemblyAiProvider {
     async fn connect(&mut self, config: &SttConfig) -> Result<(), AppError> {
-        let url = Self::build_url(config);
-        self.sample_rate = if config.sample_rate == 0 {
-            16000
-        } else {
-            config.sample_rate
-        };
+        self.sample_rate = Self::resolved_sample_rate(config);
+        let url = self.connection_url(self.sample_rate);
         self.pending.clear();
 
         let mut attempt = 0u32;
@@ -282,11 +313,13 @@ impl SttProvider for AssemblyAiProvider {
 
     async fn disconnect(&mut self) -> Result<Option<String>, AppError> {
         // Flush residual audio before Terminate so the last words are not dropped.
-        let _ = self.flush_ready(true).await;
+        self.flush_ready(true).await?;
 
         if let Some(mut ws) = self.ws.take() {
             let terminate = serde_json::json!({"type": "Terminate"});
-            let _ = ws.send(Message::Text(terminate.to_string())).await;
+            ws.send(Message::Text(terminate.to_string()))
+                .await
+                .map_err(|e| AppError::Network(e.to_string()))?;
             let final_text = read_until_termination(&mut ws).await?;
             let _ = ws.close(None).await;
             self.pending.clear();
@@ -307,6 +340,21 @@ impl SttProvider for AssemblyAiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+
+    fn test_config() -> SttConfig {
+        SttConfig {
+            api_key: "test-key".to_string(),
+            language: None,
+            smart_format: true,
+            sample_rate: 16_000,
+            resource_id: None,
+            operation_id: None,
+            managed_audio: None,
+            provider_region: None,
+        }
+    }
 
     #[test]
     fn chunk_size_matches_assemblyai_pcm16_duration_bounds() {
@@ -315,6 +363,15 @@ mod tests {
         assert_eq!(provider.bytes_for_ms(MIN_CHUNK_MS), 1600);
         assert_eq!(provider.bytes_for_ms(TARGET_CHUNK_MS), 3200);
         assert_eq!(provider.bytes_for_ms(MAX_CHUNK_MS), 32000);
+    }
+
+    #[test]
+    fn build_url_pins_current_streaming_model_and_pcm_encoding() {
+        let url = AssemblyAiProvider::build_url(16_000);
+
+        assert!(url.contains("sample_rate=16000"));
+        assert!(url.contains("encoding=pcm_s16le"));
+        assert!(url.contains("speech_model=universal-3-5-pro"));
     }
 
     #[test]
@@ -349,6 +406,23 @@ mod tests {
 
         match event {
             Some(TranscriptEvent::Partial { text }) => assert_eq!(text, "hello world"),
+            other => panic!("expected partial transcript, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_turn_is_formatted_does_not_finalize_turn() {
+        let message = serde_json::json!({
+            "type": "Turn",
+            "end_of_turn": true,
+            "transcript": "hello"
+        })
+        .to_string();
+
+        let event = parse_transcript_message(&message).unwrap();
+
+        match event {
+            Some(TranscriptEvent::Partial { text }) => assert_eq!(text, "hello"),
             other => panic!("expected partial transcript, got {other:?}"),
         }
     }
@@ -390,5 +464,223 @@ mod tests {
         append_final_text(&mut final_text, "world ");
 
         assert_eq!(final_text, "hello world");
+    }
+
+    #[tokio::test]
+    async fn streams_buffered_frames_and_drains_final_turns_until_termination() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+
+            ws.send(Message::Text(
+                serde_json::json!({"type": "Begin"}).to_string(),
+            ))
+            .await
+            .unwrap();
+
+            let audio = ws.next().await.unwrap().unwrap();
+            match audio {
+                Message::Binary(bytes) => assert_eq!(bytes.len(), 3200),
+                other => panic!("expected binary audio frame, got {other:?}"),
+            }
+
+            let terminate = ws.next().await.unwrap().unwrap().into_text().unwrap();
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&terminate).unwrap()["type"],
+                "Terminate"
+            );
+
+            ws.send(Message::Text(
+                serde_json::json!({
+                    "type": "Turn",
+                    "end_of_turn": true,
+                    "turn_is_formatted": true,
+                    "transcript": "hello"
+                })
+                .to_string(),
+            ))
+            .await
+            .unwrap();
+            ws.send(Message::Text(
+                serde_json::json!({
+                    "type": "Turn",
+                    "end_of_turn": true,
+                    "turn_is_formatted": true,
+                    "transcript": "world"
+                })
+                .to_string(),
+            ))
+            .await
+            .unwrap();
+            ws.send(Message::Text(
+                serde_json::json!({"type": "Termination"}).to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let mut provider = AssemblyAiProvider::with_url(format!("ws://{address}"));
+        provider.connect(&test_config()).await.unwrap();
+        for _ in 0..5 {
+            provider.send_audio(&vec![1; 640]).await.unwrap();
+        }
+
+        assert_eq!(
+            provider.disconnect().await.unwrap().as_deref(),
+            Some("hello world")
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnect_pads_short_residual_before_terminate() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+
+            let audio = ws.next().await.unwrap().unwrap();
+            match audio {
+                Message::Binary(bytes) => {
+                    assert_eq!(bytes.len(), 1600);
+                    assert_eq!(&bytes[..640], vec![1; 640].as_slice());
+                    assert!(bytes[640..].iter().all(|byte| *byte == 0));
+                }
+                other => panic!("expected padded binary audio frame, got {other:?}"),
+            }
+
+            let terminate = ws.next().await.unwrap().unwrap().into_text().unwrap();
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&terminate).unwrap()["type"],
+                "Terminate"
+            );
+            ws.send(Message::Text(
+                serde_json::json!({"type": "Termination"}).to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let mut provider = AssemblyAiProvider::with_url(format!("ws://{address}"));
+        provider.connect(&test_config()).await.unwrap();
+        provider.send_audio(&vec![1; 640]).await.unwrap();
+
+        assert_eq!(provider.disconnect().await.unwrap(), None);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_audio_is_split_into_provider_sized_frames() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+
+            for _ in 0..11 {
+                let audio = ws.next().await.unwrap().unwrap();
+                match audio {
+                    Message::Binary(bytes) => assert_eq!(bytes.len(), 3200),
+                    other => panic!("expected binary audio frame, got {other:?}"),
+                }
+            }
+
+            let terminate = ws.next().await.unwrap().unwrap().into_text().unwrap();
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&terminate).unwrap()["type"],
+                "Terminate"
+            );
+            ws.send(Message::Text(
+                serde_json::json!({"type": "Termination"}).to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let mut provider = AssemblyAiProvider::with_url(format!("ws://{address}"));
+        provider.connect(&test_config()).await.unwrap();
+        provider.send_audio(&vec![1; 35_200]).await.unwrap();
+
+        assert_eq!(provider.disconnect().await.unwrap(), None);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn server_error_during_termination_is_returned() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            let _ = ws.next().await.unwrap().unwrap();
+
+            ws.send(Message::Text(
+                serde_json::json!({
+                    "type": "Error",
+                    "error": "Input duration violation: 20 ms. Expected between 50 and 1000 ms"
+                })
+                .to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let mut provider = AssemblyAiProvider::with_url(format!("ws://{address}"));
+        provider.connect(&test_config()).await.unwrap();
+
+        let error = provider.disconnect().await.unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Input duration violation: 20 ms"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn close_before_termination_is_incomplete_shutdown() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            let _ = ws.next().await.unwrap().unwrap();
+            ws.close(None).await.unwrap();
+        });
+
+        let mut provider = AssemblyAiProvider::with_url(format!("ws://{address}"));
+        provider.connect(&test_config()).await.unwrap();
+
+        let error = provider.disconnect().await.unwrap_err();
+        assert!(error.to_string().contains("closed before Termination"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn timeout_before_termination_is_incomplete_shutdown() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            let _ = ws.next().await.unwrap().unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+
+        let mut provider = AssemblyAiProvider::with_url(format!("ws://{address}"));
+        provider.connect(&test_config()).await.unwrap();
+        let ws = provider.ws.as_mut().unwrap();
+        ws.send(Message::Text(
+            serde_json::json!({"type": "Terminate"}).to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let error = read_until_termination_with_timeout(ws, Duration::from_millis(20))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AppError::Timeout(_)));
+        server.await.unwrap();
     }
 }

--- a/src-tauri/src/stt/assemblyai.rs
+++ b/src-tauri/src/stt/assemblyai.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use crate::error::AppError;
@@ -9,8 +10,18 @@ use super::{SttConfig, SttProvider, TranscriptEvent};
 type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
+// AssemblyAI Universal Streaming (v3) rejects binary frames outside 50-1000 ms.
+// OpenTypeless capture defaults to 20 ms chunks, so we re-buffer before send.
+const MIN_CHUNK_MS: u32 = 50;
+const TARGET_CHUNK_MS: u32 = 100;
+const MAX_CHUNK_MS: u32 = 1000;
+const BYTES_PER_SAMPLE: u32 = 2; // PCM s16le mono
+const TERMINATION_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub struct AssemblyAiProvider {
     ws: Option<WsStream>,
+    pending: Vec<u8>,
+    sample_rate: u32,
 }
 
 impl Default for AssemblyAiProvider {
@@ -21,7 +32,11 @@ impl Default for AssemblyAiProvider {
 
 impl AssemblyAiProvider {
     pub fn new() -> Self {
-        Self { ws: None }
+        Self {
+            ws: None,
+            pending: Vec::new(),
+            sample_rate: 16000,
+        }
     }
 
     fn build_url(config: &SttConfig) -> String {
@@ -32,12 +47,165 @@ impl AssemblyAiProvider {
             config.sample_rate
         )
     }
+
+    fn bytes_for_ms(&self, ms: u32) -> usize {
+        let rate = self.sample_rate.max(1);
+        (rate as usize) * (ms as usize) * (BYTES_PER_SAMPLE as usize) / 1000
+    }
+
+    async fn flush_ready(&mut self, force: bool) -> Result<(), AppError> {
+        let min_bytes = self.bytes_for_ms(MIN_CHUNK_MS);
+        let target_bytes = self.bytes_for_ms(TARGET_CHUNK_MS);
+        let max_bytes = self.bytes_for_ms(MAX_CHUNK_MS);
+
+        while self.pending.len() >= min_bytes || (force && !self.pending.is_empty()) {
+            if !force && self.pending.len() < target_bytes {
+                break;
+            }
+
+            let take = if force {
+                self.pending.len().min(max_bytes)
+            } else {
+                target_bytes.min(self.pending.len()).min(max_bytes)
+            };
+
+            // Never send a final undersized frame if we can avoid it; pad only on force
+            // when residual audio is shorter than the minimum (end of utterance).
+            if take < min_bytes {
+                if !force {
+                    break;
+                }
+                // Pad short residual with silence so AssemblyAI accepts the last frame.
+                let mut frame = self.pending.drain(..).collect::<Vec<u8>>();
+                frame.resize(min_bytes, 0);
+                self.send_frame(&frame).await?;
+                break;
+            }
+
+            let frame: Vec<u8> = self.pending.drain(..take).collect();
+            self.send_frame(&frame).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn send_frame(&mut self, frame: &[u8]) -> Result<(), AppError> {
+        if let Some(ws) = &mut self.ws {
+            ws.send(Message::Binary(frame.to_vec()))
+                .await
+                .map_err(|e| AppError::Network(e.to_string()))?;
+        }
+        Ok(())
+    }
+}
+
+fn parse_transcript_message(text: &str) -> Result<Option<TranscriptEvent>, AppError> {
+    let v: serde_json::Value =
+        serde_json::from_str(text).map_err(|e| AppError::Config(e.to_string()))?;
+    let msg_type = v["type"].as_str().unwrap_or("");
+
+    match msg_type {
+        "Begin" => {
+            tracing::info!(
+                "AssemblyAI session started: {}",
+                v["id"].as_str().unwrap_or("")
+            );
+            Ok(None)
+        }
+        "Turn" => {
+            let transcript = v["transcript"].as_str().unwrap_or("").to_string();
+            if transcript.is_empty() {
+                return Ok(None);
+            }
+
+            let end_of_turn = v["end_of_turn"].as_bool().unwrap_or(false);
+            let turn_is_formatted = v
+                .get("turn_is_formatted")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(end_of_turn);
+
+            if end_of_turn && turn_is_formatted {
+                Ok(Some(TranscriptEvent::Final {
+                    text: transcript,
+                    confidence: 1.0,
+                }))
+            } else {
+                Ok(Some(TranscriptEvent::Partial { text: transcript }))
+            }
+        }
+        "Termination" => {
+            tracing::info!("AssemblyAI session terminated");
+            Ok(Some(TranscriptEvent::SpeechEnded))
+        }
+        "Error" => {
+            let msg = v["error"]
+                .as_str()
+                .or_else(|| v["message"].as_str())
+                .unwrap_or("Unknown error")
+                .to_string();
+            Ok(Some(TranscriptEvent::Error { message: msg }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn append_final_text(final_text: &mut String, text: &str) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if !final_text.is_empty() {
+        final_text.push(' ');
+    }
+    final_text.push_str(trimmed);
+}
+
+async fn read_until_termination(ws: &mut WsStream) -> Result<Option<String>, AppError> {
+    let deadline = tokio::time::Instant::now() + TERMINATION_TIMEOUT;
+    let mut final_text = String::new();
+
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            tracing::warn!("Timed out waiting for AssemblyAI Termination message");
+            break;
+        }
+
+        let next = tokio::time::timeout(deadline - now, ws.next()).await;
+        match next {
+            Ok(Some(Ok(Message::Text(text)))) => match parse_transcript_message(&text)? {
+                Some(TranscriptEvent::Final { text, .. }) => {
+                    append_final_text(&mut final_text, &text);
+                }
+                Some(TranscriptEvent::SpeechEnded) => break,
+                Some(TranscriptEvent::Error { message }) => {
+                    return Err(AppError::Config(message));
+                }
+                _ => {}
+            },
+            Ok(Some(Ok(Message::Close(_)))) | Ok(None) => break,
+            Ok(Some(Err(e))) => return Err(AppError::Network(e.to_string())),
+            Ok(Some(Ok(_))) => {}
+            Err(_) => {
+                tracing::warn!("Timed out waiting for AssemblyAI Termination message");
+                break;
+            }
+        }
+    }
+
+    Ok((!final_text.is_empty()).then_some(final_text))
 }
 
 #[async_trait]
 impl SttProvider for AssemblyAiProvider {
     async fn connect(&mut self, config: &SttConfig) -> Result<(), AppError> {
         let url = Self::build_url(config);
+        self.sample_rate = if config.sample_rate == 0 {
+            16000
+        } else {
+            config.sample_rate
+        };
+        self.pending.clear();
 
         let mut attempt = 0u32;
         loop {
@@ -58,7 +226,11 @@ impl SttProvider for AssemblyAiProvider {
             match connect_async(request).await {
                 Ok((ws, _)) => {
                     self.ws = Some(ws);
-                    tracing::info!("AssemblyAI WebSocket connected");
+                    tracing::info!(
+                        "AssemblyAI WebSocket connected (re-buffer {}-{} ms for v3)",
+                        MIN_CHUNK_MS,
+                        TARGET_CHUNK_MS
+                    );
                     return Ok(());
                 }
                 Err(e) if attempt < 2 => {
@@ -79,12 +251,11 @@ impl SttProvider for AssemblyAiProvider {
     }
 
     async fn send_audio(&mut self, chunk: &[u8]) -> Result<(), AppError> {
-        if let Some(ws) = &mut self.ws {
-            ws.send(Message::Binary(chunk.to_vec()))
-                .await
-                .map_err(|e| AppError::Network(e.to_string()))?;
+        if chunk.is_empty() {
+            return Ok(());
         }
-        Ok(())
+        self.pending.extend_from_slice(chunk);
+        self.flush_ready(false).await
     }
 
     async fn recv_transcript(&mut self) -> Result<Option<TranscriptEvent>, AppError> {
@@ -94,45 +265,7 @@ impl SttProvider for AssemblyAiProvider {
         };
 
         match ws.next().await {
-            Some(Ok(Message::Text(text))) => {
-                let v: serde_json::Value =
-                    serde_json::from_str(&text).map_err(|e| AppError::Config(e.to_string()))?;
-                let msg_type = v["type"].as_str().unwrap_or("");
-
-                match msg_type {
-                    "Begin" => {
-                        tracing::info!(
-                            "AssemblyAI session started: {}",
-                            v["id"].as_str().unwrap_or("")
-                        );
-                        Ok(None)
-                    }
-                    "Turn" => {
-                        let transcript = v["transcript"].as_str().unwrap_or("").to_string();
-                        if transcript.is_empty() {
-                            return Ok(None);
-                        }
-                        let is_formatted = v["turn_is_formatted"].as_bool().unwrap_or(false);
-                        if is_formatted {
-                            Ok(Some(TranscriptEvent::Final {
-                                text: transcript,
-                                confidence: 1.0,
-                            }))
-                        } else {
-                            Ok(Some(TranscriptEvent::Partial { text: transcript }))
-                        }
-                    }
-                    "Termination" => {
-                        tracing::info!("AssemblyAI session terminated");
-                        Ok(Some(TranscriptEvent::SpeechEnded))
-                    }
-                    "Error" => {
-                        let msg = v["error"].as_str().unwrap_or("Unknown error").to_string();
-                        Ok(Some(TranscriptEvent::Error { message: msg }))
-                    }
-                    _ => Ok(None),
-                }
-            }
+            Some(Ok(Message::Text(text))) => parse_transcript_message(&text),
             Some(Ok(Message::Close(_))) => {
                 tracing::info!("AssemblyAI WebSocket closed");
                 Ok(None)
@@ -148,17 +281,114 @@ impl SttProvider for AssemblyAiProvider {
     }
 
     async fn disconnect(&mut self) -> Result<Option<String>, AppError> {
-        if let Some(ws) = &mut self.ws {
+        // Flush residual audio before Terminate so the last words are not dropped.
+        let _ = self.flush_ready(true).await;
+
+        if let Some(mut ws) = self.ws.take() {
             let terminate = serde_json::json!({"type": "Terminate"});
-            let _ = ws.send(Message::Text(terminate.to_string())).await;
+            let _ = ws.send(Message::Text(terminate.to_string().into())).await;
+            let final_text = read_until_termination(&mut ws).await?;
             let _ = ws.close(None).await;
+            self.pending.clear();
+            tracing::info!("AssemblyAI disconnected");
+            return Ok(final_text);
         }
         self.ws = None;
+        self.pending.clear();
         tracing::info!("AssemblyAI disconnected");
         Ok(None)
     }
 
     fn name(&self) -> &str {
         "AssemblyAI"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_size_matches_assemblyai_pcm16_duration_bounds() {
+        let provider = AssemblyAiProvider::new();
+
+        assert_eq!(provider.bytes_for_ms(MIN_CHUNK_MS), 1600);
+        assert_eq!(provider.bytes_for_ms(TARGET_CHUNK_MS), 3200);
+        assert_eq!(provider.bytes_for_ms(MAX_CHUNK_MS), 32000);
+    }
+
+    #[test]
+    fn parses_partial_turn_when_not_end_of_turn() {
+        let message = serde_json::json!({
+            "type": "Turn",
+            "end_of_turn": false,
+            "turn_is_formatted": false,
+            "transcript": "hello"
+        })
+        .to_string();
+
+        let event = parse_transcript_message(&message).unwrap();
+
+        match event {
+            Some(TranscriptEvent::Partial { text }) => assert_eq!(text, "hello"),
+            other => panic!("expected partial transcript, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ignores_unformatted_end_of_turn_as_partial() {
+        let message = serde_json::json!({
+            "type": "Turn",
+            "end_of_turn": true,
+            "turn_is_formatted": false,
+            "transcript": "hello world"
+        })
+        .to_string();
+
+        let event = parse_transcript_message(&message).unwrap();
+
+        match event {
+            Some(TranscriptEvent::Partial { text }) => assert_eq!(text, "hello world"),
+            other => panic!("expected partial transcript, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_formatted_end_of_turn_as_final() {
+        let message = serde_json::json!({
+            "type": "Turn",
+            "end_of_turn": true,
+            "turn_is_formatted": true,
+            "transcript": "Hello world."
+        })
+        .to_string();
+
+        let event = parse_transcript_message(&message).unwrap();
+
+        match event {
+            Some(TranscriptEvent::Final { text, confidence }) => {
+                assert_eq!(text, "Hello world.");
+                assert!((confidence - 1.0).abs() < f32::EPSILON);
+            }
+            other => panic!("expected final transcript, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_termination_as_speech_ended() {
+        let event = parse_transcript_message(r#"{"type":"Termination"}"#).unwrap();
+
+        assert!(matches!(event, Some(TranscriptEvent::SpeechEnded)));
+    }
+
+    #[test]
+    fn appends_final_text_with_single_spaces() {
+        let mut final_text = String::new();
+
+        append_final_text(&mut final_text, " hello ");
+        append_final_text(&mut final_text, "");
+        append_final_text(&mut final_text, "world ");
+
+        assert_eq!(final_text, "hello world");
     }
 }

--- a/src-tauri/src/stt/assemblyai.rs
+++ b/src-tauri/src/stt/assemblyai.rs
@@ -286,7 +286,7 @@ impl SttProvider for AssemblyAiProvider {
 
         if let Some(mut ws) = self.ws.take() {
             let terminate = serde_json::json!({"type": "Terminate"});
-            let _ = ws.send(Message::Text(terminate.to_string().into())).await;
+            let _ = ws.send(Message::Text(terminate.to_string())).await;
             let final_text = read_until_termination(&mut ws).await?;
             let _ = ws.close(None).await;
             self.pending.clear();


### PR DESCRIPTION
## Summary

Fix AssemblyAI streaming dictation by buffering the app's default 20 ms PCM capture chunks into provider-compatible frames, draining final transcript messages before closing the WebSocket, and treating incomplete shutdown as an error instead of a clean disconnect.

Root cause: OpenTypeless forwarded capture chunks directly, but AssemblyAI rejects PCM binary frames outside the documented 50-1000 ms range.

This contribution was prepared with AI assistance and manually verified locally.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Changes

- Buffer AssemblyAI PCM audio into 100 ms frames while enforcing the 50-1000 ms frame range.
- Pad only the final short residual frame so the last captured audio is sent during stop.
- Drain final formatted `Turn` messages after `Terminate` until `Termination`.
- Propagate residual flush, `Terminate` send, server `Error`, early close, and timeout failures instead of silently treating incomplete shutdown as success.
- Require `turn_is_formatted` to be explicitly true before finalizing a `Turn`.
- Pin AssemblyAI streaming to `universal-3-5-pro` with `pcm_s16le` encoding so behavior does not depend on server defaults.
- Add mock-WebSocket tests for frame aggregation, oversized frame splitting, final residual padding, shutdown ordering, final-turn draining, server errors, early close, and timeout behavior.

## Test Plan

- [x] Tested locally on Linux / Fedora KDE Wayland with AssemblyAI dictation
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/`
- [x] `npx prettier --check src/`
- [x] `npx vitest run`
- [x] `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] No regressions in existing functionality

## Screenshots / Recordings

No UI changes.

## Related Issues

None.