### PR TITLE
feat: allow configurable single-key shortcuts

### DIFF
--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -414,7 +414,8 @@ pub fn native_trigger_supported_on_platform(trigger: NativeHotkeyTrigger, platfo
         ),
         "windows" => matches!(
             trigger,
-            NativeHotkeyTrigger::RightAlt
+            NativeHotkeyTrigger::LeftAlt
+                | NativeHotkeyTrigger::RightAlt
                 | NativeHotkeyTrigger::RightAltSpace
                 | NativeHotkeyTrigger::RightAltLeftShift
         ),
@@ -428,6 +429,9 @@ pub fn native_trigger_from_binding(
     if binding.modifiers.is_empty() {
         return match binding.primary.trim().to_lowercase().as_str() {
             "fn" | "function" => Some(NativeHotkeyTrigger::Fn),
+            "leftalt" | "left_alt" | "left-alt" | "altleft" | "alt_left" | "alt-left" => {
+                Some(NativeHotkeyTrigger::LeftAlt)
+            }
             "rightalt" | "right_alt" | "right-alt" | "altright" | "alt_right" | "alt-right" => {
                 Some(NativeHotkeyTrigger::RightAlt)
             }
@@ -1244,6 +1248,25 @@ mod tests {
     }
 
     #[test]
+    fn native_left_alt_dictation_uses_native_adapter_plan() {
+        let dictation = storage::ShortcutBinding {
+            primary: "LeftAlt".to_string(),
+            modifiers: vec![],
+        };
+        let config = storage::HotkeyConfig {
+            dictation_bindings: vec![dictation.clone()],
+            dictation,
+            ..storage::HotkeyConfig::default()
+        };
+
+        let plan = hotkey_registration_plan_from_config_for_platform(&config, "windows")
+            .expect("LeftAlt should be supported on Windows");
+
+        assert_eq!(plan.native.len(), 1);
+        assert_eq!(plan.native[0].trigger, NativeHotkeyTrigger::LeftAlt);
+    }
+
+    #[test]
     fn native_typeless_mode_shortcuts_use_native_adapter_plan() {
         let dictation = storage::ShortcutBinding::from_hotkey("Fn").unwrap();
         let ask = storage::ShortcutBinding::from_hotkey("Fn+Space");
@@ -1472,6 +1495,10 @@ mod tests {
         assert!(!native_trigger_supported_on_platform(
             NativeHotkeyTrigger::RightAlt,
             "macos"
+        ));
+        assert!(native_trigger_supported_on_platform(
+            NativeHotkeyTrigger::LeftAlt,
+            "windows"
         ));
         assert!(native_trigger_supported_on_platform(
             NativeHotkeyTrigger::RightAltLeftShift,

--- a/src-tauri/src/native_hotkey.rs
+++ b/src-tauri/src/native_hotkey.rs
@@ -8,6 +8,7 @@ pub enum NativeHotkeyTrigger {
     Fn,
     FnSpace,
     FnLeftShift,
+    LeftAlt,
     RightAlt,
     RightAltSpace,
     RightAltLeftShift,
@@ -19,6 +20,7 @@ impl NativeHotkeyTrigger {
             Self::Fn => "Fn",
             Self::FnSpace => "Fn+Space",
             Self::FnLeftShift => "Fn+LeftShift",
+            Self::LeftAlt => "LeftAlt",
             Self::RightAlt => "RightAlt",
             Self::RightAltSpace => "RightAlt+Space",
             Self::RightAltLeftShift => "RightAlt+LeftShift",
@@ -29,6 +31,7 @@ impl NativeHotkeyTrigger {
     fn base(self) -> NativeHotkeyTrigger {
         match self {
             Self::Fn | Self::FnSpace | Self::FnLeftShift => Self::Fn,
+            Self::LeftAlt => Self::LeftAlt,
             Self::RightAlt | Self::RightAltSpace | Self::RightAltLeftShift => Self::RightAlt,
         }
     }
@@ -38,7 +41,7 @@ impl NativeHotkeyTrigger {
         match self {
             Self::FnSpace | Self::RightAltSpace => Some(NativeComboKey::Space),
             Self::FnLeftShift | Self::RightAltLeftShift => Some(NativeComboKey::LeftShift),
-            Self::Fn | Self::RightAlt => None,
+            Self::Fn | Self::LeftAlt | Self::RightAlt => None,
         }
     }
 
@@ -143,7 +146,7 @@ impl NativeMonitoredBinding {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows", test))]
+#[cfg(target_os = "macos")]
 fn monitored_bindings_for_base(
     bindings: Vec<NativeHotkeyBinding>,
     base: NativeHotkeyTrigger,
@@ -275,9 +278,8 @@ fn dispatch_native_combo_edge(
 #[cfg(target_os = "macos")]
 mod platform {
     use super::{
-        dispatch_native_base_edge, dispatch_native_combo_edge, monitored_bindings_for_base,
-        NativeComboKey, NativeComboState, NativeHotkeyHandler, NativeHotkeyTrigger,
-        NativeMonitoredBinding,
+        dispatch_native_base_edge, dispatch_native_combo_edge, NativeComboKey, NativeComboState,
+        NativeHotkeyHandler, NativeHotkeyTrigger, NativeMonitoredBinding,
     };
     use std::ffi::c_void;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -626,9 +628,8 @@ mod platform {
 #[cfg(target_os = "windows")]
 mod platform {
     use super::{
-        dispatch_native_base_edge, dispatch_native_combo_edge, monitored_bindings_for_base,
-        NativeComboKey, NativeComboState, NativeHotkeyHandler, NativeHotkeyTrigger,
-        NativeMonitoredBinding,
+        dispatch_native_base_edge, dispatch_native_combo_edge, NativeComboKey, NativeComboState,
+        NativeHotkeyHandler, NativeHotkeyTrigger, NativeMonitoredBinding,
     };
     use std::ptr;
     use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, Ordering as AtomicOrdering};
@@ -653,6 +654,7 @@ mod platform {
     const WM_SYSKEYUP: usize = 0x0105;
     const VK_SPACE: u32 = 0x20;
     const VK_LSHIFT: u32 = 0xA0;
+    const VK_LMENU: u32 = 0xA4;
     const VK_RMENU: u32 = 0xA5;
 
     static HOOK_CONTEXT: AtomicPtr<CallbackContext> = AtomicPtr::new(ptr::null_mut());
@@ -699,9 +701,21 @@ mod platform {
             bindings: Vec<super::NativeHotkeyBinding>,
             handler: NativeHotkeyHandler,
         ) -> Result<Self, String> {
-            let bindings = monitored_bindings_for_base(bindings, NativeHotkeyTrigger::RightAlt);
+            let bindings: Vec<_> = bindings
+                .into_iter()
+                .filter(|binding| {
+                    matches!(
+                        binding.trigger,
+                        NativeHotkeyTrigger::LeftAlt
+                            | NativeHotkeyTrigger::RightAlt
+                            | NativeHotkeyTrigger::RightAltSpace
+                            | NativeHotkeyTrigger::RightAltLeftShift
+                    )
+                })
+                .map(NativeMonitoredBinding::new)
+                .collect();
             if bindings.is_empty() {
-                return Err("Windows native hotkeys currently support RightAlt only".to_string());
+                return Err("Windows native hotkeys require a supported Alt binding".to_string());
             }
 
             let (status_tx, status_rx) = mpsc::channel();
@@ -762,7 +776,8 @@ mod platform {
         bindings: Vec<NativeMonitoredBinding>,
         handler: NativeHotkeyHandler,
         hook: std::sync::Mutex<Option<HHOOK>>,
-        state: std::sync::Mutex<NativeComboState>,
+        right_alt_state: std::sync::Mutex<NativeComboState>,
+        left_alt_state: std::sync::Mutex<NativeComboState>,
     }
 
     unsafe impl Send for CallbackContext {}
@@ -792,7 +807,8 @@ mod platform {
                 bindings,
                 handler,
                 hook: std::sync::Mutex::new(None),
-                state: std::sync::Mutex::new(NativeComboState::default()),
+                right_alt_state: std::sync::Mutex::new(NativeComboState::default()),
+                left_alt_state: std::sync::Mutex::new(NativeComboState::default()),
             }));
             HOOK_CONTEXT.store(context, AtomicOrdering::SeqCst);
 
@@ -909,17 +925,32 @@ mod platform {
             return false;
         };
 
-        let mut state = context.state.lock().unwrap_or_else(|e| e.into_inner());
         match vk_code {
+            VK_LMENU => dispatch_native_base_edge(
+                &mut context
+                    .left_alt_state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()),
+                &context.bindings,
+                NativeHotkeyTrigger::LeftAlt,
+                pressed,
+                &context.handler,
+            ),
             VK_RMENU => dispatch_native_base_edge(
-                &mut state,
+                &mut context
+                    .right_alt_state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()),
                 &context.bindings,
                 NativeHotkeyTrigger::RightAlt,
                 pressed,
                 &context.handler,
             ),
             VK_SPACE => dispatch_native_combo_edge(
-                &mut state,
+                &mut context
+                    .right_alt_state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()),
                 &context.bindings,
                 NativeHotkeyTrigger::RightAlt,
                 NativeComboKey::Space,
@@ -927,7 +958,10 @@ mod platform {
                 &context.handler,
             ),
             VK_LSHIFT => dispatch_native_combo_edge(
-                &mut state,
+                &mut context
+                    .right_alt_state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()),
                 &context.bindings,
                 NativeHotkeyTrigger::RightAlt,
                 NativeComboKey::LeftShift,

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -458,11 +458,6 @@ impl AppConfig {
             self.hotkey = "Fn".to_string();
             self.hotkey_mode = "toggle".to_string();
         }
-        #[cfg(target_os = "windows")]
-        if self.hotkey == "RightAlt" && self.hotkey_mode == "toggle" {
-            self.hotkey = "Ctrl+/".to_string();
-            self.hotkey_mode = "hold".to_string();
-        }
         #[cfg(target_os = "macos")]
         if self.ask_hotkey == "Alt+Shift+/"
             || self.ask_hotkey == "Option+Shift+/"
@@ -508,13 +503,6 @@ impl AppConfig {
     fn migrate_platform_typed_hotkeys(&mut self) {
         #[cfg(target_os = "windows")]
         {
-            if self.hotkeys.dictation.to_hotkey_string().as_deref() == Some("RightAlt") {
-                if let Some(binding) = ShortcutBinding::from_hotkey("Ctrl+/") {
-                    self.hotkeys.dictation = binding.clone();
-                    self.hotkeys.dictation_bindings = vec![binding];
-                }
-                self.hotkeys.dictation_mode = "hold".to_string();
-            }
             if self
                 .hotkeys
                 .ask
@@ -807,6 +795,9 @@ fn normalize_optional_binding(binding: &mut Option<ShortcutBinding>) {
 fn normalize_hotkey_modifier(value: &str) -> Option<(&'static str, &'static str)> {
     match value.trim().to_lowercase().as_str() {
         "fn" | "function" => Some(("fn", "Fn")),
+        "leftalt" | "left_alt" | "left-alt" | "altleft" | "alt_left" | "alt-left" => {
+            Some(("leftalt", "LeftAlt"))
+        }
         "rightalt" | "right_alt" | "right-alt" | "altright" | "alt_right" | "alt-right" => {
             Some(("rightalt", "RightAlt"))
         }
@@ -822,7 +813,7 @@ fn normalize_hotkey_modifier(value: &str) -> Option<(&'static str, &'static str)
 
 fn hotkey_modifier_rank(value: &str) -> u8 {
     match value {
-        "Fn" | "RightAlt" => 0,
+        "Fn" | "LeftAlt" | "RightAlt" => 0,
         "Command" | "Super" => 0,
         "Ctrl" => 1,
         "Option" | "Alt" => 2,
@@ -857,6 +848,9 @@ fn normalize_hotkey_primary(value: &str) -> Option<String> {
         "arrowleft" | "left" => "Left".to_string(),
         "arrowright" | "right" => "Right".to_string(),
         "fn" | "function" => "Fn".to_string(),
+        "leftalt" | "left_alt" | "left-alt" | "altleft" | "alt_left" | "alt-left" => {
+            "LeftAlt".to_string()
+        }
         "rightalt" | "right_alt" | "right-alt" | "altright" | "alt_right" | "alt-right" => {
             "RightAlt".to_string()
         }
@@ -2402,6 +2396,11 @@ mod tests {
         assert_eq!(right_alt.primary, "RightAlt");
         assert!(right_alt.modifiers.is_empty());
         assert_eq!(right_alt.to_hotkey_string().as_deref(), Some("RightAlt"));
+
+        let left_alt = ShortcutBinding::from_hotkey("LeftAlt").expect("LeftAlt parses");
+        assert_eq!(left_alt.primary, "LeftAlt");
+        assert!(left_alt.modifiers.is_empty());
+        assert_eq!(left_alt.to_hotkey_string().as_deref(), Some("LeftAlt"));
     }
 
     #[test]
@@ -3127,6 +3126,24 @@ mod tests {
         );
         assert_eq!(config.hotkey_mode, "hold");
         assert_eq!(config.hotkeys.dictation_mode, "hold");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn app_config_preserves_single_right_alt_dictation_hotkey() {
+        let value = serde_json::json!({
+            "hotkey": "RightAlt",
+            "ask_hotkey": "Ctrl+.",
+            "hotkey_mode": "toggle"
+        });
+
+        let config = AppConfig::from_stored_value(value).unwrap();
+
+        assert_eq!(config.hotkey, "RightAlt");
+        assert_eq!(config.hotkeys.dictation.primary, "RightAlt");
+        assert!(config.hotkeys.dictation.modifiers.is_empty());
+        assert_eq!(config.hotkey_mode, "toggle");
+        assert_eq!(config.hotkeys.dictation_mode, "toggle");
     }
 
     #[test]

--- a/src/components/Settings/GeneralPane.tsx
+++ b/src/components/Settings/GeneralPane.tsx
@@ -96,7 +96,9 @@ export function GeneralPane() {
     !accessibilityTrusted &&
     hotkeyRegistrationError?.includes('Accessibility permission may be denied'),
   )
-  const dictationSpecialOptions = isMac ? [{ value: 'Fn', label: 'Fn' }] : []
+  const dictationSpecialOptions = isMac
+    ? [{ value: 'Fn', label: 'Fn' }]
+    : []
   const askSpecialOptions = isMac ? [{ value: 'Fn+Space', label: 'Fn + Space' }] : []
   const translateSpecialOptions = isMac ? [{ value: 'Fn+LeftShift', label: 'Fn + Left Shift' }] : []
   const dictationBindings = config.hotkeys.dictationBindings?.length

--- a/src/components/Settings/ShortcutBindingList.tsx
+++ b/src/components/Settings/ShortcutBindingList.tsx
@@ -6,36 +6,6 @@ import type { HotkeyRole } from '../../lib/tauri'
 import type { ShortcutBinding } from '../../stores/appStore'
 import { pauseHotkey, resumeHotkey } from '../../lib/tauri'
 
-const STANDALONE_KEYS = new Set([
-  'Space',
-  'Tab',
-  'Enter',
-  'Backspace',
-  'Escape',
-  'Delete',
-  'Insert',
-  'Home',
-  'End',
-  'PageUp',
-  'PageDown',
-  'Up',
-  'Down',
-  'Left',
-  'Right',
-  'F1',
-  'F2',
-  'F3',
-  'F4',
-  'F5',
-  'F6',
-  'F7',
-  'F8',
-  'F9',
-  'F10',
-  'F11',
-  'F12',
-])
-
 const MAX_BINDINGS = 3
 
 interface HotkeyRecorderProps {
@@ -133,6 +103,20 @@ export function HotkeyRecorder({
       event.preventDefault()
       event.stopPropagation()
 
+      // `KeyboardEvent.key` identifies either Alt key as "Alt". The physical
+      // code preserves the side for a standalone Alt binding.
+      const standaloneAlt = !isMac
+        ? event.code === 'AltLeft'
+          ? 'LeftAlt'
+          : event.code === 'AltRight'
+            ? 'RightAlt'
+            : null
+        : null
+      if (standaloneAlt) {
+        confirmHotkey(standaloneAlt)
+        return
+      }
+
       const parts: string[] = []
       if (isMac && event.metaKey) parts.push('Command')
       if (event.ctrlKey) parts.push('Ctrl')
@@ -167,8 +151,6 @@ export function HotkeyRecorder({
       }
       let keyName = keyMap[event.key] || event.key
       if (keyName.length === 1) keyName = keyName.toUpperCase()
-      if (parts.length === 0 && !STANDALONE_KEYS.has(keyName)) return
-
       parts.push(keyName)
       const combo = parts.join('+')
       setPending(combo)

--- a/src/components/Settings/__tests__/Settings.test.tsx
+++ b/src/components/Settings/__tests__/Settings.test.tsx
@@ -605,7 +605,7 @@ describe('Settings tab 切换', () => {
     expect(screen.queryByText('settings.hotkeyInvalid')).toBeNull()
   })
 
-  it('does not offer Windows RightAlt as a default shortcut chip', async () => {
+  it('records Windows single-key shortcuts, including distinct Alt sides', async () => {
     const originalPlatform = window.navigator.platform
     Object.defineProperty(window.navigator, 'platform', {
       value: 'Win32',
@@ -619,17 +619,26 @@ describe('Settings tab 切换', () => {
       clipboardAutoPasteReliable: true,
     })
 
+    vi.useFakeTimers()
     try {
       renderSettings()
 
-      fireEvent.click(screen.getByText('Ctrl+.'))
-      expect(screen.queryByRole('button', { name: 'Right Alt' })).toBeNull()
-      fireEvent.click(screen.getByText('settings.pressKeyCombination'))
-
       fireEvent.click(screen.getByText('Ctrl+/'))
-      expect(screen.queryByRole('button', { name: 'Right Alt' })).toBeNull()
-      expect(useAppStore.getState().config.hotkey).toBe('Ctrl+/')
+      fireEvent.keyDown(window, { key: 'Alt', code: 'AltRight' })
+      expect(useAppStore.getState().config.hotkey).toBe('RightAlt')
+
+      fireEvent.click(screen.getByText('RightAlt'))
+      fireEvent.keyDown(window, { key: 'Alt', code: 'AltLeft' })
+      expect(useAppStore.getState().config.hotkey).toBe('LeftAlt')
+
+      fireEvent.click(screen.getByText('LeftAlt'))
+      fireEvent.keyDown(window, { key: 'p', code: 'KeyP' })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1600)
+      })
+      expect(useAppStore.getState().config.hotkey).toBe('P')
     } finally {
+      vi.useRealTimers()
       Object.defineProperty(window.navigator, 'platform', {
         value: originalPlatform,
         configurable: true,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -377,13 +377,20 @@ function defaultTranslateHotkey(): string | null {
   return 'Ctrl+Shift+/'
 }
 
-const modifierOrder = ['Fn', 'RightAlt', 'Command', 'Super', 'Ctrl', 'Option', 'Alt', 'Shift']
+const modifierOrder = ['Fn', 'LeftAlt', 'RightAlt', 'Command', 'Super', 'Ctrl', 'Option', 'Alt', 'Shift']
 
 function normalizeModifier(value: string): string | null {
   switch (value.trim().toLowerCase()) {
     case 'fn':
     case 'function':
       return 'Fn'
+    case 'leftalt':
+    case 'left_alt':
+    case 'left-alt':
+    case 'altleft':
+    case 'alt_left':
+    case 'alt-left':
+      return 'LeftAlt'
     case 'rightalt':
     case 'right_alt':
     case 'right-alt':
@@ -451,6 +458,12 @@ function normalizePrimary(value: string): string | null {
   const nativePrimary: Record<string, string> = {
     fn: 'Fn',
     function: 'Fn',
+    leftalt: 'LeftAlt',
+    left_alt: 'LeftAlt',
+    'left-alt': 'LeftAlt',
+    altleft: 'LeftAlt',
+    alt_left: 'LeftAlt',
+    'alt-left': 'LeftAlt',
     rightalt: 'RightAlt',
     right_alt: 'RightAlt',
     'right-alt': 'RightAlt',


### PR DESCRIPTION
## Summary
- allow any non-modifier key to be recorded as a standalone shortcut
- distinguish and support LeftAlt and RightAlt native shortcuts on Windows
- preserve existing single RightAlt bindings during configuration migration

## Tests
- npm test -- --run src/components/Settings/__tests__/Settings.test.tsx
- cargo test app_config_preserves_single_right_alt_dictation_hotkey
- cargo test native_left_alt_dictation_uses_native_adapter_plan