### PR TITLE
fix: restore cloud session before webview startup

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,6 +74,7 @@ libloading = "0.8"
 
 [dev-dependencies]
 plist = "1"
+tauri = { version = "=2.11.2", features = ["test"] }
 
 [profile.release]
 codegen-units = 1

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,21 @@ pub struct HotkeyRegistrationError(pub Arc<Mutex<Option<String>>>);
 /// The main renderer may restore it for authenticated API calls; native STT/LLM reads it directly.
 pub struct SessionTokenStore(pub Arc<Mutex<String>>);
 
+fn with_restored_session_token<R, V>(builder: tauri::Builder<R>, vault: &V) -> tauri::Builder<R>
+where
+    R: tauri::Runtime,
+    V: credentials::CredentialSecretReader,
+{
+    let token = credentials::load_cloud_session_token(vault)
+        .unwrap_or_else(|error| {
+            tracing::warn!("Failed to restore cloud session from the system vault: {error}");
+            None
+        })
+        .unwrap_or_default();
+
+    builder.manage(SessionTokenStore(Arc::new(Mutex::new(token))))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AutoStartSyncOutcome {
     config_auto_start: bool,
@@ -258,6 +273,7 @@ async fn show_ask_window(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
 
     fn text_mentions(text: &str, keywords: &[&str]) -> bool {
         let normalized = text.to_ascii_lowercase();
@@ -278,6 +294,30 @@ mod tests {
     fn desktop_client_version_header_matches_frontend_contract() {
         assert_eq!(crate::CLIENT_VERSION_HEADER, "X-OpenTypeless-Version");
         assert_eq!(crate::desktop_client_version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    struct StaticSessionVault(&'static str);
+
+    impl credentials::CredentialSecretReader for StaticSessionVault {
+        fn get_secret(&self, _namespace: &str, _provider: &str) -> Result<Option<String>> {
+            Ok(Some(self.0.to_string()))
+        }
+    }
+
+    #[test]
+    fn cloud_session_state_is_managed_before_setup_and_window_scripts() {
+        let app = with_restored_session_token(
+            tauri::test::mock_builder(),
+            &StaticSessionVault("restored-token"),
+        )
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .unwrap();
+
+        let state = app.state::<SessionTokenStore>();
+        assert_eq!(
+            state.0.lock().unwrap_or_else(|e| e.into_inner()).as_str(),
+            "restored-token"
+        );
     }
 
     #[test]
@@ -833,7 +873,14 @@ pub fn run() {
         }
     }
 
-    tauri::Builder::default()
+    // Builder-managed state exists before Tauri creates configured webviews.
+    // Registering this in `.setup(...)` races the main renderer's first invoke on WebView2.
+    let builder = with_restored_session_token(
+        tauri::Builder::default(),
+        &credentials::SystemCredentialVault,
+    );
+
+    builder
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_autostart::init(
@@ -929,19 +976,6 @@ pub fn run() {
             app.manage(CloseToTrayCache(Arc::new(Mutex::new(
                 initial_config.close_to_tray,
             ))));
-            let initial_session_token =
-                credentials::load_cloud_session_token(&credentials::SystemCredentialVault)
-                    .unwrap_or_else(|error| {
-                        tracing::warn!(
-                            "Failed to restore cloud session from the system vault: {error}"
-                        );
-                        None
-                    })
-                    .unwrap_or_default();
-            app.manage(SessionTokenStore(Arc::new(Mutex::new(
-                initial_session_token,
-            ))));
-
             // Register global shortcut from config
             let handler = hotkey::build_shortcut_handler(app_handle.clone());
             app.handle().plugin(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,6 @@ function AskApp() {
   const setConfig = useAppStore((s) => s.setConfig)
 
   useEffect(() => {
-    useAuthStore.getState().initialize()
     getConfig()
       .then((config) => {
         setConfig(config)

--- a/src/lib/__tests__/auth-client-session.test.ts
+++ b/src/lib/__tests__/auth-client-session.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { invoke } from '@tauri-apps/api/core'
-import { requestOpenTypelessPasswordReset } from '../auth-client'
+import { authClient, requestOpenTypelessPasswordReset } from '../auth-client'
 import { resetCloudSessionCoordinatorForTests } from '../cloud-session'
-import { APP_VERSION_HEADER_VALUE, CLIENT_VERSION_HEADER } from '../constants'
+import { API_BASE_URL, APP_VERSION_HEADER_VALUE, CLIENT_VERSION_HEADER } from '../constants'
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 
@@ -39,5 +39,30 @@ describe('auth client cloud session transport', () => {
     expect(invoke).toHaveBeenCalledTimes(1)
     expect(invoke).toHaveBeenCalledWith('get_session_token')
     expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('adds the restored bearer to Better Auth session restoration', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          user: { id: 'user-1', email: 'person@example.com', name: 'Person' },
+          session: { id: 'session-1' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const result = await authClient.getSession()
+
+    expect(result.data?.user.id).toBe('user-1')
+    expect(invoke).toHaveBeenCalledTimes(1)
+    expect(invoke).toHaveBeenCalledWith('get_session_token')
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!
+    const headers = new Headers(init?.headers)
+    expect(String(url)).toBe(`${API_BASE_URL}/api/auth/get-session`)
+    expect(init?.method).toBe('GET')
+    expect(headers.get('Authorization')).toBe('Bearer vault-token')
+    expect(headers.get(CLIENT_VERSION_HEADER)).toBe(APP_VERSION_HEADER_VALUE)
+    expect(localStorage.getItem('session_token')).toBeNull()
   })
 })

--- a/src/stores/__tests__/authStore.restart.test.ts
+++ b/src/stores/__tests__/authStore.restart.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('../../components/toast-service', () => ({ toast: vi.fn() }))
+
+import { invoke } from '@tauri-apps/api/core'
+import { API_BASE_URL, APP_VERSION_HEADER_VALUE, CLIENT_VERSION_HEADER } from '../../lib/constants'
+import { resetCloudSessionCoordinatorForTests } from '../../lib/cloud-session'
+import { useAuthStore } from '../authStore'
+
+describe('authStore restart recovery', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    resetCloudSessionCoordinatorForTests()
+    useAuthStore.setState({
+      user: null,
+      plan: 'free',
+      source: 'free',
+      displayName: 'Free',
+      licenseStatus: null,
+      subscriptionRefreshState: 'unknown',
+      subscriptionLastVerifiedAt: null,
+      loading: false,
+      error: null,
+    })
+
+    vi.mocked(invoke).mockImplementation((command) =>
+      Promise.resolve(command === 'get_session_token' ? 'vault-token' : undefined),
+    )
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input)
+        if (url === `${API_BASE_URL}/api/auth/get-session`) {
+          return new Response(
+            JSON.stringify({
+              user: {
+                id: 'user-1',
+                email: 'person@example.com',
+                name: 'Person',
+                emailVerified: true,
+              },
+              session: { id: 'session-1' },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        if (url === `${API_BASE_URL}/api/auth/list-accounts`) {
+          return new Response(JSON.stringify([{ providerId: 'credential' }]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        if (url === `${API_BASE_URL}/api/subscription/status`) {
+          return new Response(
+            JSON.stringify({
+              plan: 'lifetime_starter',
+              source: 'lifetime',
+              displayName: 'Lifetime Starter',
+              subscriptionEnd: null,
+              subscriptionStatus: 'active',
+              licenseStatus: 'active',
+              quotaModel: 'legacy_dual_meter',
+              displayWordsUsedEstimate: 0,
+              displayWordsLimit: 0,
+              displayWordsResetAt: null,
+              sttSecondsUsed: 0,
+              sttSecondsLimit: 0,
+              llmTokensUsed: 0,
+              llmTokensLimit: 0,
+              cloudWordsUsed: 0,
+              cloudWordsLimit: 0,
+              cloudWordsResetAt: null,
+              byokUnlimited: true,
+              accountSnapshot: {
+                schemaVersion: 1,
+                userId: 'user-1',
+                managedSttCapabilities: {
+                  version: 1,
+                  maxRecordingSeconds: 600,
+                  maxMultipartBytes: 25_000_000,
+                  formats: [{ mimeType: 'audio/wav', maxAudioBytes: 25_000_000 }],
+                },
+                generatedAt: '2026-09-08T00:00:00.000Z',
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      }),
+    )
+  })
+
+  it('restores a paid account and managed recording limit from the vault token', async () => {
+    await useAuthStore.getState().initialize()
+
+    const state = useAuthStore.getState()
+    expect(state.user?.id).toBe('user-1')
+    expect(state.plan).toBe('lifetime_starter')
+    expect(state.licenseStatus).toBe('active')
+    expect(state.subscriptionRefreshState).toBe('fresh')
+    expect(invoke).toHaveBeenCalledWith('get_session_token')
+    expect(invoke).toHaveBeenCalledWith('cache_managed_stt_capability', {
+      accountSnapshot: expect.objectContaining({
+        userId: 'user-1',
+        managedSttCapabilities: expect.objectContaining({ maxRecordingSeconds: 600 }),
+      }),
+      expectedUserId: 'user-1',
+    })
+    expect(invoke).not.toHaveBeenCalledWith('clear_managed_stt_capability')
+
+    for (const [, init] of vi.mocked(fetch).mock.calls) {
+      const headers = new Headers(init?.headers)
+      expect(headers.get('Authorization')).toBe('Bearer vault-token')
+      expect(headers.get(CLIENT_VERSION_HEADER)).toBe(APP_VERSION_HEADER_VALUE)
+    }
+    expect(localStorage.getItem('session_token')).toBeNull()
+  })
+})

--- a/src/stores/__tests__/authStore.test.ts
+++ b/src/stores/__tests__/authStore.test.ts
@@ -423,6 +423,25 @@ describe('authStore', () => {
     it('stays null user when no session exists', async () => {
       await getState().initialize()
       expect(getState().user).toBeNull()
+      expect(getState().error).toBeNull()
+    })
+
+    it('surfaces session restoration failures instead of treating them as signed out', async () => {
+      vi.mocked(authClient.getSession).mockResolvedValue({
+        data: null,
+        error: { message: 'service unavailable' },
+      } as never)
+      const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await getState().initialize()
+
+      expect(getState().user).toBeNull()
+      expect(getState().error).toBe('service unavailable')
+      expect(warning).toHaveBeenCalledWith(
+        'Failed to restore cloud session:',
+        'service unavailable',
+      )
+      warning.mockRestore()
     })
 
     it('propagates email verification and credential capability from Better Auth', async () => {
@@ -445,6 +464,36 @@ describe('authStore', () => {
 
       expect(getState().user?.emailVerified).toBe(true)
       expect(getState().credentialCapability).toBe('present')
+    })
+
+    it('restores subscription state even when account capability lookup fails', async () => {
+      vi.mocked(authClient.getSession).mockResolvedValue({
+        data: {
+          user: {
+            id: '1',
+            email: 'person@example.com',
+            name: 'Person',
+            emailVerified: true,
+          },
+        },
+      } as never)
+      vi.mocked(authClient.listAccounts).mockResolvedValue({
+        data: null,
+        error: { message: 'account endpoint unavailable' },
+      } as never)
+      const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await getState().initialize()
+
+      expect(getState().user?.id).toBe('1')
+      expect(getState().credentialCapability).toBe('unknown')
+      expect(getSubscriptionStatus).toHaveBeenCalledTimes(1)
+      expect(getState().plan).toBe('pro')
+      expect(warning).toHaveBeenCalledWith(
+        'Failed to restore account security capability:',
+        expect.any(Error),
+      )
+      warning.mockRestore()
     })
   })
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -248,7 +248,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     try {
       set({ loading: true, error: null })
       const savedToken = await loadSessionToken()
-      const { data: session } = await authClient.getSession()
+      const { data: session, error: sessionError } = await authClient.getSession()
+      if (sessionError) {
+        throw new Error(sessionError.message ?? 'Failed to restore cloud session')
+      }
       if (session?.user) {
         set({
           user: {
@@ -261,11 +264,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         if (savedToken) {
           markCloudSessionAuthenticated()
         }
-        await get().refreshCredentialCapability()
+        try {
+          await get().refreshCredentialCapability()
+        } catch (error) {
+          console.warn('Failed to restore account security capability:', error)
+        }
         await get().refreshSubscription()
       }
-    } catch {
-      // Not logged in — that's fine
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn('Failed to restore cloud session:', message)
+      set({ error: message })
     } finally {
       set({ loading: false })
     }


### PR DESCRIPTION
## Summary

Fixes the Windows cold-start sign-out regression reported in #111. Tauri creates configured webviews before `.setup(...)`; the cloud `SessionTokenStore` was registered inside `.setup(...)`, so WebView2 could invoke `get_session_token` before the managed state existed. The rejected startup restore was then treated as signed out for the lifetime of that process.

This change restores the vault token onto the Tauri builder before any configured webview can run, and makes genuine restore failures observable without changing the normal no-session path.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Changes

- manage the vault-restored `SessionTokenStore` on `tauri::Builder` before configured webviews are created
- add a Tauri mock-builder regression test proving restored state is managed before setup/window scripts
- exercise the real Better Auth `getSession()` transport and assert it uses the vault bearer and desktop version header
- add a cold-restart integration test: empty renderer storage plus a valid vault token restores the paid user, active Lifetime Starter entitlement, and 600-second managed recording capability without clearing it
- distinguish a genuine no-session response from a restoration error
- keep subscription recovery independent of the optional account-capability lookup
- remove the Ask renderer's invalid auth initialization; native Ask paths read the Rust session store directly

## Test Plan

- [x] Tested locally on macOS
- [x] `npm run build`
- [x] `npx vitest run` — 49 files / 453 tests
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml` — 565 tests
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] No regressions found in two independent read-only reviews

## Screenshots / Recordings

Not applicable; no UI changes.

## Related Issues

Related to #111. The issue will be closed after the Windows release artifact is built and verified.

AI assistance was used for implementation and review; all behavior and regression coverage were verified locally.
